### PR TITLE
리뷰 조회 리턴 타입 수정

### DIFF
--- a/src/main/java/com/liberty52/product/service/controller/dto/ReviewRetrieveResponse.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/ReviewRetrieveResponse.java
@@ -46,7 +46,8 @@ public class ReviewRetrieveResponse {
 
     public void setReviewAuthor( Map<String, AuthClientDataResponse> reviewAuthorId){
         contents.forEach(c -> {
-            c.author = reviewAuthorId.get(c.authorId).getAuthorName();
+            c.authorName = reviewAuthorId.get(c.authorId).getAuthorName();
+            c.authorProfileUrl = reviewAuthorId.get(c.authorId).getAuthorProfileUrl();
             c.setReplyAuthor(reviewAuthorId);
         });
     }
@@ -65,7 +66,8 @@ public class ReviewRetrieveResponse {
         private Boolean isYours;
         @JsonIgnore
         private String authorId;
-        private String author; // openfeign으로 채울 값
+        private String authorName; // openfeign으로 채울 값
+        private String authorProfileUrl;
         private List<ReplyContent> replies;
 
         public ReviewContent(String reviewId, Integer rating, String content, List<String> imageUrls,

--- a/src/test/java/com/liberty52/product/service/applicationservice/ReviewRetrieveServiceImplTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/ReviewRetrieveServiceImplTest.java
@@ -4,7 +4,6 @@ import static com.liberty52.product.service.utils.MockConstants.MOCK_AUTHOR_NAME
 import static com.liberty52.product.service.utils.MockConstants.MOCK_AUTHOR_PROFILE_URL;
 import static org.assertj.core.api.Assertions.*;
 
-import com.liberty52.product.global.adapter.AuthClient;
 import com.liberty52.product.global.config.DBInitConfig.DBInitService;
 import com.liberty52.product.service.controller.dto.ReviewRetrieveResponse;
 import com.liberty52.product.service.controller.dto.ReviewRetrieveResponse.ReplyContent;
@@ -15,12 +14,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 
 
 @ActiveProfiles("test,dev")
@@ -59,7 +54,8 @@ class ReviewRetrieveServiceImplTest {
 
         ReviewContent content = response.getContents().get(0);
         assertThat(content.getContent()).isEqualTo("good");
-        assertThat(content.getAuthor()).isEqualTo(MOCK_AUTHOR_NAME);
+        assertThat(content.getAuthorName()).isEqualTo(MOCK_AUTHOR_NAME);
+        assertThat(content.getAuthorProfileUrl()).isEqualTo(MOCK_AUTHOR_PROFILE_URL);
         assertThat(content.getRating()).isSameAs(3);
         assertThat(content.getImageUrls().size()).isSameAs(1);
 


### PR DESCRIPTION
## 스프린트 넘버  :  4
## 메이저 마일스톤 : 상품
### 마이너 마일스톤 : 리뷰
### 백로그 이름 : 리뷰 관리


***
### 작업

리뷰 조회 시 리턴 타입 수정
- 작성자 프로필 사진 url 추가
- 작성자 명 필드 이름 수정 author -> authorName

**API**
```
{
   "contents":[
      {
         "reviewId":"string", 리뷰 아이디
         "rating":"number",  평점
         "content":"string", 내용
         "imageUrls":[       첨부 이미지 주소
            "string..."
         ],
         "isYours":"boolean", 자신이 작성한 것인지 유무 // true 일 경우 삭제 or 수정 버튼 표기


         "authorName":"string",   작성자 이름  //               <--  기존의 "author" 에서 이름 변경
         "authorProfileUrl":"string", 작성자 프로필 사진 // null 일 경우엔 기본 이미지 표시  <-- 새로 추가 


         "replies":[
            {
               "replyId":"string",             답글 아이디
               "isYours":"boolean",            자신이 작성한 것인지 유무 // true 일 경우 삭제 or 수정 버튼 표기
               "authorName":"string",          작성자 이름
               "authorProfileUrl":"string",    작성자 프로필 사진 // null 일 경우엔 기본 이미지 표시
               "content":"string"              내용
            }
         ],
         "nofReply":"number"                  답글 수
      }
   ],
   "currentPage":"number",                  현재 페이지
   "startPage":"number",                    시작 페이지
   "lastPage":"number"                      마지막 페이지
}
```
***
### 테스트 결과

![image](https://user-images.githubusercontent.com/76154390/233562276-ee6b2ae3-159b-420a-837d-a10d2963bcb8.png)

***
### 이슈

추후에 openFeign에 대한 설정을 더해야한다.
openFeign을 통한 조회 테스트는 못해서 클라우드 환경에서 테스트 해봐야 할 듯 하다.
