### PR TITLE
LIB-140 feat: 비회원 카트아이템 단 건 삭제

### DIFF
--- a/src/main/java/com/liberty52/product/service/applicationservice/CartItemRemoveService.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/CartItemRemoveService.java
@@ -8,4 +8,6 @@ public interface CartItemRemoveService {
     void removeCartItemList(String authId, CartItemListRemoveRequestDto dto);
 
     void removeGuestCartItemList(String guestId, CartItemListRemoveRequestDto dto);
+
+    void removeGuestCartItem(String guestId, String cartItemId);
 }

--- a/src/main/java/com/liberty52/product/service/applicationservice/CartItemRemoveServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/CartItemRemoveServiceImpl.java
@@ -41,6 +41,11 @@ public class CartItemRemoveServiceImpl implements CartItemRemoveService {
         removeCartItems(guestId, dto.getIds());
     }
 
+    @Override
+    public void removeGuestCartItem(String guestId, String cartItemId) {
+        removeCartItem(guestId, cartItemId);
+    }
+
     private CustomProduct validAndGetCartItem(String authId, String cartItemId) {
         CustomProduct cartItem = cartItemRepository.findById(cartItemId).orElseThrow(() -> new ResourceNotFoundException(RESOURCE_NAME_CART_ITEM, PARAM_NAME_ID, cartItemId));
         validCartItem(authId, cartItem);

--- a/src/main/java/com/liberty52/product/service/controller/CartItemRemoveController.java
+++ b/src/main/java/com/liberty52/product/service/controller/CartItemRemoveController.java
@@ -27,6 +27,12 @@ public class CartItemRemoveController {
         cartItemRemoveService.removeCartItemList(authId, dto);
     }
 
+    @DeleteMapping("/guest/carts/custom-products/{customProductId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void guestCartItemRemove(@RequestHeader(HttpHeaders.AUTHORIZATION) String guestId, @PathVariable String customProductId) {
+        cartItemRemoveService.removeGuestCartItem(guestId, customProductId);
+    }
+
     @DeleteMapping("/guest/carts/custom-products")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void guestCartItemListRemove(@RequestHeader(HttpHeaders.AUTHORIZATION)


### PR DESCRIPTION
## 스프린트 넘버  : 4
## 메이저 마일스톤 : 상품
### 마이너 마일스톤 : 장바구니
### 백로그 이름 : 비회원 장바구니 삭제
비회원 카트아이템 단 건 삭제 엔드포인트 추가

***
**API**
```
DELETE /product/guest/carts/custom-products/{customProductId}
Request Header: {
  "Authorization": string // id of guset
}
Status:
  204: 성공
  400: 요청 헤더 Authorization 파싱 에러
  404: customProductId에 해당하는 리소스가 없음
  403:
    - 해당 CustomProduct가 요청자의 것이 아니어서 삭제할 수 없음
    - 해당 CustomProduct가 CartItem이 아니라 OrderItem이라 삭제할 수 없다
```
**CODE** 
현재 내부 로직은 회원 카트아이템 단 건 삭제와 같음.

***
### 테스트 결과
없음