### PR TITLE
refactor: 테스트 시 S3 mockbean을 세팅한다

### DIFF
--- a/src/test/java/com/liberty52/product/MockS3Test.java
+++ b/src/test/java/com/liberty52/product/MockS3Test.java
@@ -1,0 +1,36 @@
+package com.liberty52.product;
+
+import com.liberty52.product.global.adapter.s3.S3Uploader;
+import com.liberty52.product.global.adapter.s3.S3UploaderApi;
+import com.liberty52.product.global.exception.internal.S3UploaderException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class MockS3Test {
+    @MockBean
+    protected S3UploaderApi s3UploaderApi;
+
+    @MockBean
+    protected S3Uploader s3Uploader;
+
+    @BeforeEach
+    public void initMockBeans() {
+        when(s3UploaderApi.upload(any())).thenReturn("mock s3 return");
+        doNothing().when(s3UploaderApi).delete(any());
+        try {
+            when(s3Uploader.upload(any())).thenReturn("mock s3 return");
+            doNothing().when(s3Uploader).delete(any());
+        } catch (S3UploaderException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/liberty52/product/service/applicationservice/CartItemCreateServiceTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/CartItemCreateServiceTest.java
@@ -1,5 +1,6 @@
 package com.liberty52.product.service.applicationservice;
 
+import com.liberty52.product.MockS3Test;
 import com.liberty52.product.global.exception.external.notfound.OptionDetailNotFoundByNameException;
 import com.liberty52.product.global.exception.external.notfound.ProductNotFoundByNameException;
 import com.liberty52.product.service.controller.dto.CartItemRequest;
@@ -22,7 +23,7 @@ import java.util.List;
 
 @SpringBootTest
 @Transactional
-public class CartItemCreateServiceTest {
+public class CartItemCreateServiceTest extends MockS3Test {
 
     @Autowired
     CartItemCreateService cartItemCreateService;
@@ -32,7 +33,6 @@ public class CartItemCreateServiceTest {
 
     @Autowired
     CartRepository cartRepository;
-
 
     @Test
     void 장바구니생성() throws IOException {

--- a/src/test/java/com/liberty52/product/service/applicationservice/CartItemModifyServiceTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/CartItemModifyServiceTest.java
@@ -1,16 +1,13 @@
 package com.liberty52.product.service.applicationservice;
 
+import com.liberty52.product.MockS3Test;
 import com.liberty52.product.service.controller.dto.CartModifyRequestDto;
 import com.liberty52.product.service.entity.Cart;
 import com.liberty52.product.service.entity.CustomProduct;
 import com.liberty52.product.service.entity.CustomProductOption;
 import com.liberty52.product.service.entity.Product;
-import com.liberty52.product.service.repository.CartItemRepository;
-import com.liberty52.product.service.repository.CartRepository;
-import com.liberty52.product.service.repository.CustomProductOptionRepository;
-import com.liberty52.product.service.repository.OptionDetailRepository;
-import com.liberty52.product.service.repository.ProductOptionRepository;
-import com.liberty52.product.service.repository.ProductRepository;
+import com.liberty52.product.service.repository.*;
+
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -18,23 +15,24 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
-class CartItemModifyServiceTest {
+class CartItemModifyServiceTest extends MockS3Test {
 
   @Autowired
-  MonoItemOrderService monoItemOrderService;
-  @Autowired
-  CartItemRepository customProductRepository;
+  CustomProductRepository customProductRepository;
   @Autowired
   ProductRepository productRepository;
   @Autowired
@@ -46,6 +44,8 @@ class CartItemModifyServiceTest {
   OptionDetailRepository optionDetailRepository;
   @Autowired
   CartRepository cartRepository;
+  @Autowired
+  ApplicationEventPublisher eventPublisher;
 
   @Autowired
   CartItemModifyService cartItemModifyService;

--- a/src/test/java/com/liberty52/product/service/applicationservice/CartItemRemoveServiceImplTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/CartItemRemoveServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.liberty52.product.service.applicationservice;
 
+import com.liberty52.product.MockS3Test;
 import com.liberty52.product.global.exception.external.forbidden.NotYourResourceException;
 import com.liberty52.product.global.exception.external.forbidden.UnRemovableResourceException;
 import com.liberty52.product.service.controller.dto.CartItemListRemoveRequestDto;
@@ -21,7 +22,7 @@ import java.util.stream.IntStream;
 
 @SpringBootTest
 @Transactional
-class CartItemRemoveServiceImplTest {
+class CartItemRemoveServiceImplTest extends MockS3Test {
     @Autowired
     CartItemRemoveService cartItemRemoveService;
     @Autowired

--- a/src/test/java/com/liberty52/product/service/applicationservice/ReviewCreateServiceImplTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/ReviewCreateServiceImplTest.java
@@ -1,22 +1,13 @@
 package com.liberty52.product.service.applicationservice;
 
+import com.liberty52.product.MockS3Test;
 import com.liberty52.product.service.controller.dto.ReplyCreateRequestDto;
 import com.liberty52.product.service.controller.dto.ReviewCreateRequestDto;
-import com.liberty52.product.service.entity.CustomProduct;
-import com.liberty52.product.service.entity.OrderDestination;
-import com.liberty52.product.service.entity.Orders;
-import com.liberty52.product.service.entity.Product;
-import com.liberty52.product.service.entity.Reply;
-import com.liberty52.product.service.entity.Review;
+import com.liberty52.product.service.entity.*;
 import com.liberty52.product.service.repository.CustomProductRepository;
 import com.liberty52.product.service.repository.OrdersRepository;
 import com.liberty52.product.service.repository.ProductRepository;
 import com.liberty52.product.service.repository.ReviewRepository;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -27,10 +18,16 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
-class ReviewCreateServiceImplTest {
+class ReviewCreateServiceImplTest extends MockS3Test {
   @Autowired
   private OrdersRepository ordersRepository;
   @Autowired

--- a/src/test/java/com/liberty52/product/service/applicationservice/ReviewModifyServiceImplTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/ReviewModifyServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.liberty52.product.service.applicationservice;
 
+import com.liberty52.product.MockS3Test;
 import com.liberty52.product.global.config.DBInitConfig;
 import com.liberty52.product.global.exception.internal.InvalidRatingException;
 import com.liberty52.product.global.exception.internal.InvalidTextSize;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,10 +30,13 @@ import java.util.stream.IntStream;
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
-class ReviewModifyServiceImplTest {
+class ReviewModifyServiceImplTest extends MockS3Test {
 
     @Autowired
     private ReviewRepository reviewRepository;
+
+    @Autowired
+    ApplicationEventPublisher eventPublisher;
 
     @Autowired
     private ReviewModifyService reviewModifyService;
@@ -42,8 +47,6 @@ class ReviewModifyServiceImplTest {
     private List<ReviewImage> images;
 
     String authId = DBInitConfig.DBInitService.AUTH_ID;
-    MockMultipartFile imageFile = newImageFile();
-
 
     private MockMultipartFile newImageFile() {
         try {

--- a/src/test/java/com/liberty52/product/service/applicationservice/ReviewRemoveServiceTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/ReviewRemoveServiceTest.java
@@ -1,22 +1,26 @@
 package com.liberty52.product.service.applicationservice;
 
+import com.liberty52.product.MockS3Test;
 import com.liberty52.product.global.config.DBInitConfig;
 import com.liberty52.product.global.exception.external.forbidden.NotYourReviewException;
 import com.liberty52.product.global.exception.external.notfound.ReviewNotFoundByIdException;
 import com.liberty52.product.service.entity.Review;
 import com.liberty52.product.service.repository.ReviewRepository;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
 @SpringBootTest
 @Transactional
-public class ReviewRemoveServiceTest {
+public class ReviewRemoveServiceTest extends MockS3Test {
 
     @Autowired
     ReviewRepository reviewRepository;
@@ -24,9 +28,13 @@ public class ReviewRemoveServiceTest {
     @Autowired
     ReviewRemoveService reviewRemoveService;
 
+    @Autowired
+    ApplicationEventPublisher eventPublisher;
+
     private Review review;
 
     String reviewerId;
+
     @BeforeEach
     void beforeEach() {
         review = DBInitConfig.DBInitService.getReview();


### PR DESCRIPTION
### 이슈 : LIB-152


***
### 작업
`S3Uploader`의 `@MockBean`을 주입하는 `MockS3Test`
```java
@ExtendWith(MockitoExtension.class)
@TestInstance(TestInstance.Lifecycle.PER_CLASS)
public class MockS3Test {
    @MockBean
    protected S3UploaderApi s3UploaderApi;

    @MockBean
    protected S3Uploader s3Uploader;

    @BeforeEach
    public void initMockBeans() {
        when(s3UploaderApi.upload(any())).thenReturn("mock s3 return");
        doNothing().when(s3UploaderApi).delete(any());
        try {
            when(s3Uploader.upload(any())).thenReturn("mock s3 return");
            doNothing().when(s3Uploader).delete(any());
        } catch (S3UploaderException e) {
            throw new RuntimeException(e);
        }
    }
}
```

사용 예) `S3Uploader`를 사용하는 테스트는 `MockS3Test`를 상속받는다.
```java
@SpringBootTest
@AutoConfigureMockMvc
@Transactional
class MonoItemOrderServiceImplTest extends MockS3Test {
    // ...
}
```

~또는 `MockS3Test`를 멤버로 가지고 `@BeforeEach`에서 `MockS3Test.initMockBeans()`를 호출한다.~
 -> 안된다.

***
### 테스트 결과
기존 applicationservice 테스트들에 적용 및 동작 확인
