### PR TITLE
테스트용 CustomProduct에 옵션 디테일들 넣어주기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ out/
 ### secret
 
 /src/main/resources/bootstrap.yml
+/src/main/java/com/liberty52/product/global/config/CorsConfig.java
 
 # trash
 spy.log

--- a/src/main/java/com/liberty52/product/global/config/DBInitConfig.java
+++ b/src/main/java/com/liberty52/product/global/config/DBInitConfig.java
@@ -130,10 +130,7 @@ public class DBInitConfig {
                 customProduct.associateWithCart(cart);
                 customProductRepository.save(customProduct);
 
-                CustomProductOption customProductOption = CustomProductOption.create();
-                customProductOption.associate(detailEasel);
-                customProductOption.associate(customProduct);
-                customProductOptionRepository.save(customProductOption);
+                associateCustomProductOption(detailEasel, material, materialOption2, customProduct);
 
                 // Add Order
                 Orders order = ordersRepository.save(
@@ -148,10 +145,7 @@ public class DBInitConfig {
                 customProduct.associateWithOrder(order);
                 customProductRepository.save(customProduct);
 
-                customProductOption = CustomProductOption.create();
-                customProductOption.associate(detailEasel);
-                customProductOption.associate(customProduct);
-                customProductOptionRepository.save(customProductOption);
+                associateCustomProductOption(detailEasel, material, materialOption2, customProduct);
                 Payment<?> payment = Payment.cardOf();
                 PortOnePaymentInfo info = PortOnePaymentInfo.testOf(
                         UUID.randomUUID().toString(), UUID.randomUUID().toString(), 100L,
@@ -186,10 +180,7 @@ public class DBInitConfig {
                 customProduct.associateWithOrder(orderSub);
                 customProductRepository.save(customProduct);
 
-                customProductOption = CustomProductOption.create();
-                customProductOption.associate(detailEasel);
-                customProductOption.associate(customProduct);
-                customProductOptionRepository.save(customProductOption);
+                associateCustomProductOption(detailEasel, material, materialOption2, customProduct);
                 Payment<? extends PaymentInfo> vbank = Payment.vbankOf();
                 vbank.setInfo(VBankPayment.VBankPaymentInfo.of("하나은행 1234123412341234 리버티","하나은행", "김테스터", "138-978554-10547",false));
                 vbank.associate(orderSub);
@@ -212,10 +203,7 @@ public class DBInitConfig {
                     customProduct.associateWithOrder(guestOrder);
                     customProductRepository.save(customProduct);
 
-                    customProductOption = CustomProductOption.create();
-                    customProductOption.associate(customProduct);
-                    customProductOption.associate(detailEasel);
-                    customProductOptionRepository.save(customProductOption);
+                    associateCustomProductOption(detailEasel, material, materialOption2, customProduct);
 
                     Review noPhotoReview = Review.create(3, "good");
                     noPhotoReview.associate(guestOrder);
@@ -239,6 +227,24 @@ public class DBInitConfig {
             } catch (Exception e) {
                 e.printStackTrace();
             }
+        }
+
+        private void associateCustomProductOption(OptionDetail detailEasel, OptionDetail material,
+                OptionDetail materialOption2, CustomProduct customProduct) {
+            CustomProductOption customProductOption = CustomProductOption.create();
+            customProductOption.associate(detailEasel);
+            customProductOption.associate(customProduct);
+            customProductOptionRepository.save(customProductOption);
+
+            customProductOption = CustomProductOption.create();
+            customProductOption.associate(material);
+            customProductOption.associate(customProduct);
+            customProductOptionRepository.save(customProductOption);
+
+            customProductOption = CustomProductOption.create();
+            customProductOption.associate(materialOption2);
+            customProductOption.associate(customProduct);
+            customProductOptionRepository.save(customProductOption);
         }
 
         public static Orders getOrder() {


### PR DESCRIPTION
## 스프린트 넘버  : 6

### 이슈 번호 : #112 

FE 장바구니에서 에러 발생해서, 찾던 중 OptionDetail들이 원래 개수만큼(3) 없어서 생기는 문제가 발생했다.
이를 해결하기 위해 1개만 넣어주던 OptionDetail을 3개씩 넉넉하게 넣어주었다.

***
### 작업
아래 메서드를 extract 해서 모든 CustomProduct에 적용해주었다.
```java
  private void associateCustomProductOption(OptionDetail detailEasel, OptionDetail material,
                OptionDetail materialOption2, CustomProduct customProduct) {
            CustomProductOption customProductOption = CustomProductOption.create();
            customProductOption.associate(detailEasel);
            customProductOption.associate(customProduct);
            customProductOptionRepository.save(customProductOption);

            customProductOption = CustomProductOption.create();
            customProductOption.associate(material);
            customProductOption.associate(customProduct);
            customProductOptionRepository.save(customProductOption);

            customProductOption = CustomProductOption.create();
            customProductOption.associate(materialOption2);
            customProductOption.associate(customProduct);
            customProductOptionRepository.save(customProductOption);
        }
```

***
### 테스트 결과
넉넉하게 넣어두었다.
![image](https://user-images.githubusercontent.com/76154390/236674223-a89c28c5-429d-462c-8c2a-de619096de46.png)
FE도 잘 나온다.
![image](https://user-images.githubusercontent.com/76154390/236674232-599e7352-2275-4b79-ac24-1aced3538acc.png)
