### PR TITLE
비회원 장바구니 주문 버그 수정

### DIFF
--- a/src/main/java/com/liberty52/product/service/applicationservice/OrderCreateService.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/OrderCreateService.java
@@ -18,4 +18,7 @@ public interface OrderCreateService {
 
     PaymentVBankResponseDto createVBankPaymentOrdersByCarts(String authId, OrderCreateRequestDto dto);
 
+    PaymentCardResponseDto createCardPaymentOrdersByCartsForGuest(String authId, OrderCreateRequestDto dto);
+
+    PaymentVBankResponseDto createVBankPaymentOrdersByCartsForGuest(String authId, OrderCreateRequestDto dto);
 }

--- a/src/main/java/com/liberty52/product/service/controller/guest/GuestOrderCreateController.java
+++ b/src/main/java/com/liberty52/product/service/controller/guest/GuestOrderCreateController.java
@@ -53,7 +53,7 @@ public class GuestOrderCreateController {
             @RequestHeader(HttpHeaders.AUTHORIZATION) String guestId,
             @RequestBody @Validated OrderCreateRequestDto dto
     ) {
-        return orderCreateService.createCardPaymentOrdersByCarts(guestId, dto);
+        return orderCreateService.createCardPaymentOrdersByCartsForGuest(guestId, dto);
     }
 
     @PostMapping("/guest/orders/vbank/carts")
@@ -62,7 +62,7 @@ public class GuestOrderCreateController {
             @RequestHeader(HttpHeaders.AUTHORIZATION) String guestId,
             @RequestBody @Validated OrderCreateRequestDto dto
     ) {
-        return orderCreateService.createVBankPaymentOrdersByCarts(guestId, dto);
+        return orderCreateService.createVBankPaymentOrdersByCartsForGuest(guestId, dto);
     }
 
 }


### PR DESCRIPTION
## 스프린트 넘버  : 7
## 메이저 마일스톤 : 상품
### 마이너 마일스톤 : 주문
### 백로그 이름 : -


***
### 작업

비회원 장바구니 주문 시 발생한 버그를 수정하였다.

기존에는 요청 헤더의 Authorization 필드에 수취자 휴대폰 번호를 담아 요청하였는데,  
서버에서는 이를 authId로 가정하고, Order 엔티티를 생성하고자 하였다. 

하지만 장바구니로 생성된 CustomProduct를 조회해서 가져오는 과정에서,  
비회원이 장바구니를 생성할 때의 authId는 UUID이기에, CustomProduct의 authId가 `UUID != 수취자 휴대폰번호`가 발생하여  
주문이 완료되지 못하였다.

따라서 기존 요청 헤더의 Authorization 필드에 쿠키에 담겨있는 authId로 요청하게 하고,  
Order 엔티티 생성 시에는 수취자 휴대폰 번호를 authId로 설정하여 저장하도록 하는 비회원 장바구니 주문 생성 메소드를 구현하였다.

**API**

**CODE** 


***
### 테스트 결과


***
### 이슈
프론트엔드의 코드도 수정해야한다.

당첨
![image](https://user-images.githubusercontent.com/42243302/237024183-3d0e8d35-3794-4d5a-b3d0-bab271e2f86b.png)

