### PR TITLE
비회원 주문 조회 로직 변경

### DIFF
--- a/src/main/java/com/liberty52/product/service/applicationservice/OrderRetrieveService.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/OrderRetrieveService.java
@@ -9,4 +9,6 @@ public interface OrderRetrieveService {
     List<OrdersRetrieveResponse> retrieveOrders(String authId);
 
      OrderDetailRetrieveResponse retrieveOrderDetail(String authId, String orderId);
+
+    OrderDetailRetrieveResponse retrieveGuestOrderDetail(String authId, String orderNumber);
 }

--- a/src/main/java/com/liberty52/product/service/applicationservice/OrderRetrieveServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/OrderRetrieveServiceImpl.java
@@ -26,9 +26,18 @@ public class OrderRetrieveServiceImpl implements
                 .stream().map(OrdersRetrieveResponse::new).toList();
     }
 
+
+
     @Override
     public OrderDetailRetrieveResponse retrieveOrderDetail(String authId, String orderId) {
         Orders orders = orderQueryDslRepository.retrieveOrderDetail(authId, orderId)
+                .orElseThrow(CannotAccessOrderException::new);
+        return new OrderDetailRetrieveResponse(orders);
+    }
+
+    @Override
+    public OrderDetailRetrieveResponse retrieveGuestOrderDetail(String authId, String orderNumber) {
+        Orders orders = orderQueryDslRepository.retrieveGuestOrderDetail(authId, orderNumber)
                 .orElseThrow(CannotAccessOrderException::new);
         return new OrderDetailRetrieveResponse(orders);
     }

--- a/src/main/java/com/liberty52/product/service/controller/guest/GuestOrderRetrieveController.java
+++ b/src/main/java/com/liberty52/product/service/controller/guest/GuestOrderRetrieveController.java
@@ -16,12 +16,11 @@ public class GuestOrderRetrieveController {
 
     private final OrderRetrieveService orderRetrieveService;
 
-    @GetMapping("/guest/orders/{orderId}")
+    @GetMapping("/guest/orders/{orderNumber}")
     public ResponseEntity<OrderDetailRetrieveResponse> retrieveGuestOrderDetail(
         @RequestHeader(HttpHeaders.AUTHORIZATION) String guestId,
-        @PathVariable("orderId") String orderId
-    ){
-        return ResponseEntity.ok(orderRetrieveService.retrieveOrderDetail(guestId,orderId));
+        @PathVariable("orderNumber") String orderNumber){
+        return ResponseEntity.ok(orderRetrieveService.retrieveGuestOrderDetail(guestId,orderNumber));
     }
 
 }

--- a/src/main/java/com/liberty52/product/service/repository/OrderQueryDslRepository.java
+++ b/src/main/java/com/liberty52/product/service/repository/OrderQueryDslRepository.java
@@ -11,4 +11,6 @@ public interface OrderQueryDslRepository {
     List<Orders> retrieveOrders(String authId);
 
     Optional<Orders> retrieveOrderDetail(String authId, String orderId);
+
+    Optional<Orders> retrieveGuestOrderDetail(String authId, String orderNumber);
 }

--- a/src/test/java/com/liberty52/product/service/applicationservice/OrderRetrieveServiceTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/OrderRetrieveServiceTest.java
@@ -16,6 +16,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.liberty52.product.global.exception.external.badrequest.CannotAccessOrderException;
+import com.liberty52.product.service.entity.OrderDestination;
+import com.liberty52.product.service.entity.Orders;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -86,7 +88,7 @@ class OrderRetrieveServiceTest {
     void retrieveOrderDetail_Throw_cannot_access_order () throws Exception{
         //given
         //when
-        assertThatThrownBy(() ->  orderRetrieveService.retrieveOrderDetail(
+        assertThatThrownBy(() ->  orderRetrieveService.retrieveGuestOrderDetail(
                 "WrongID", "WrongID"))
                 .isInstanceOf(CannotAccessOrderException.class);
 

--- a/src/test/java/com/liberty52/product/service/controller/OrderRetrieveControllerTest.java
+++ b/src/test/java/com/liberty52/product/service/controller/OrderRetrieveControllerTest.java
@@ -121,7 +121,7 @@ class OrderRetrieveControllerTest {
     @Test
     void retrieveGuestOrderDetail () throws Exception{
         //given
-        given(orderRetrieveService.retrieveOrderDetail(MOCK_AUTH_ID, MOCK_ORDER_ID))
+        given(orderRetrieveService.retrieveGuestOrderDetail(MOCK_AUTH_ID, MOCK_ORDER_ID))
                 .willReturn(createMockOrderDetailRetrieveResponse());
 
         //when
@@ -149,7 +149,7 @@ class OrderRetrieveControllerTest {
     @Test
     void retrieveGuestOrderDetail_throw_cannot_access () throws Exception{
         //given
-        given(orderRetrieveService.retrieveOrderDetail(MOCK_AUTH_ID, MOCK_ORDER_ID))
+        given(orderRetrieveService.retrieveGuestOrderDetail(MOCK_AUTH_ID, MOCK_ORDER_ID))
                 .willThrow(CannotAccessOrderException.class);
         given(exceptionHandler.handleGlobalException(any(),any()))
                 .willReturn(

--- a/src/test/java/com/liberty52/product/service/repository/OrderQueryDslRepositoryImplTest.java
+++ b/src/test/java/com/liberty52/product/service/repository/OrderQueryDslRepositoryImplTest.java
@@ -28,6 +28,25 @@ class OrderQueryDslRepositoryImplTest {
     }
 
     @Test
+    void retrieveGuestOrderDetail () throws Exception{
+        final String PHONE_NUM = "bar";
+        final OrderDestination orderDestination = OrderDestination.create("","",PHONE_NUM,"","","");
+        //given
+        Orders orders = Orders.create(PHONE_NUM, orderDestination);
+        orders.changeOrderStatusToOrdered();
+        String orderNum = orders.getOrderNum();
+        em.persist(orders);
+        em.flush();
+        em.clear();
+        //when
+
+        Orders guestOrder = repository.retrieveGuestOrderDetail(PHONE_NUM, orderNum)
+                .orElseThrow();
+        //then
+        assertThat(guestOrder.getAuthId()).isEqualTo(PHONE_NUM);
+    }
+
+    @Test
     void ready_filtering_test () throws Exception{
         //given
         final String AUTH_ID = "user";


### PR DESCRIPTION
## 스프린트 넘버  :  7
### 이슈 번호 : #125 

***
### 작업

비회원 주문 로직을 변경했다.
비회원 식별값과 OrderNum을 받아서 조회하는 것으로 변경.




***
### 테스트 결과
JUNIT
![image](https://github.com/Liberty52/product/assets/76154390/eab5b575-237d-4045-ae8c-0fcd7c10fe30)
```java
    @Test
    void retrieveGuestOrderDetail () throws Exception{
        final String PHONE_NUM = "bar";
        final OrderDestination orderDestination = OrderDestination.create("","",PHONE_NUM,"","","");
        //given
        Orders orders = Orders.create(PHONE_NUM, orderDestination);
        orders.changeOrderStatusToOrdered();
        String orderNum = orders.getOrderNum();
        em.persist(orders);
        em.flush();
        em.clear();
        //when

        Orders guestOrder = repository.retrieveGuestOrderDetail(PHONE_NUM, orderNum)
                .orElseThrow();
        //then
        assertThat(guestOrder.getAuthId()).isEqualTo(PHONE_NUM);
    }

```


POSTMAN
![image](https://github.com/Liberty52/product/assets/76154390/7edd146e-510f-4407-a6b6-f44a02f82ac2)





***
### 이슈
