### PR TITLE
Lib 246 옵션 선택지 추가

### DIFF
--- a/src/main/java/com/liberty52/product/service/applicationservice/OptionDetailCreateService.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/OptionDetailCreateService.java
@@ -1,2 +1,7 @@
-package com.liberty52.product.service.applicationservice;public interface OptionDetailCreateService {
+package com.liberty52.product.service.applicationservice;
+
+import com.liberty52.product.service.controller.dto.CreateOptionDetailRequestDto;
+
+public interface OptionDetailCreateService {
+    void createOptionDetail(String role, CreateOptionDetailRequestDto dto, String optionId);
 }

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/OptionDetailCreateServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/OptionDetailCreateServiceImpl.java
@@ -1,2 +1,37 @@
-package com.liberty52.product.service.applicationservice.impl;public class OptionDetailCreateServiceImpl {
+package com.liberty52.product.service.applicationservice.impl;
+
+import com.liberty52.product.global.exception.external.forbidden.InvalidRoleException;
+import com.liberty52.product.global.exception.external.notfound.ResourceNotFoundException;
+import com.liberty52.product.service.applicationservice.OptionDetailCreateService;
+import com.liberty52.product.service.controller.dto.CreateOptionDetailRequestDto;
+import com.liberty52.product.service.entity.OptionDetail;
+import com.liberty52.product.service.entity.ProductOption;
+import com.liberty52.product.service.repository.OptionDetailRepository;
+import com.liberty52.product.service.repository.ProductOptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.liberty52.product.global.contants.RoleConstants.ADMIN;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class OptionDetailCreateServiceImpl implements OptionDetailCreateService {
+
+    private final ProductOptionRepository productOptionRepository;
+    private final OptionDetailRepository optionDetailRepository;
+
+    @Override
+    public void createOptionDetail(String role, CreateOptionDetailRequestDto dto, String optionId) {
+
+        if(!ADMIN.equals(role)) {
+            throw new InvalidRoleException(role);
+        }
+
+        ProductOption productOption = productOptionRepository.findById(optionId).orElseThrow(() -> new ResourceNotFoundException("option", "id", optionId));
+        OptionDetail optionDetail = OptionDetail.create(dto.getName(), dto.getPrice(), dto.getOnSail());
+        optionDetail.associate(productOption);
+        optionDetailRepository.save(optionDetail);
+    }
 }

--- a/src/main/java/com/liberty52/product/service/controller/OptionDetailCreateController.java
+++ b/src/main/java/com/liberty52/product/service/controller/OptionDetailCreateController.java
@@ -1,2 +1,22 @@
-package com.liberty52.product.service.controller;public class ProductOptionCreateController {
+package com.liberty52.product.service.controller;
+
+import com.liberty52.product.service.applicationservice.OptionDetailCreateService;
+import com.liberty52.product.service.controller.dto.CreateOptionDetailRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class OptionDetailCreateController {
+
+    private final OptionDetailCreateService optionDetailCreateService;
+
+    @PostMapping("/optionDetail/{optionId}")
+    @ResponseStatus(HttpStatus.CREATED)
+    public void createOptionDetail(@RequestHeader("LB-Role") String role,
+                                   @Validated @RequestBody CreateOptionDetailRequestDto dto, @PathVariable String optionId) {
+        optionDetailCreateService.createOptionDetail(role, dto, optionId);
+    }
 }

--- a/src/main/java/com/liberty52/product/service/controller/dto/CreateOptionDetailRequestDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/CreateOptionDetailRequestDto.java
@@ -1,2 +1,28 @@
-package com.liberty52.product.service.controller.dto;public class CreateOptionDetailDto {
+package com.liberty52.product.service.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class CreateOptionDetailRequestDto {
+
+    @NotBlank
+    String name;
+
+    @NotBlank
+    Integer price;
+
+    @NotNull
+    Boolean onSail;
+
+    public static CreateOptionDetailRequestDto create(String name, int price, boolean onSail){
+        CreateOptionDetailRequestDto dto = new CreateOptionDetailRequestDto();
+        dto.name = name;
+        dto.price = price;
+        dto.onSail = onSail;
+        return dto;
+    }
+
+
 }

--- a/src/test/java/com/liberty52/product/service/applicationservice/OptionDetailCreateServiceTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/OptionDetailCreateServiceTest.java
@@ -1,2 +1,52 @@
-package com.liberty52.product.service.applicationservice;public class OptionDetailCreateServiceTest {
+package com.liberty52.product.service.applicationservice;
+
+import com.liberty52.product.global.exception.external.notfound.ProductNotFoundByNameException;
+import com.liberty52.product.global.exception.external.notfound.ResourceNotFoundException;
+import com.liberty52.product.service.controller.dto.CreateOptionDetailRequestDto;
+import com.liberty52.product.service.entity.OptionDetail;
+import com.liberty52.product.service.entity.Product;
+import com.liberty52.product.service.entity.ProductOption;
+import com.liberty52.product.service.repository.ProductOptionRepository;
+import com.liberty52.product.service.repository.ProductRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.liberty52.product.global.contants.RoleConstants.ADMIN;
+
+@SpringBootTest
+@Transactional
+public class OptionDetailCreateServiceTest {
+
+    @Autowired
+    OptionDetailCreateService optionDetailCreateService;
+
+    @Autowired
+    ProductOptionRepository productOptionRepository;
+
+    @Autowired
+    ProductRepository productRepository;
+
+    @Test
+    void 옵션선택지추가(){
+        String name = "테스트선택지";
+
+        Product product = productRepository.findByName("Liberty 52_Frame").orElseGet(null);
+        String optionId = product.getProductOptions().get(0).getId();
+
+        CreateOptionDetailRequestDto createOptionDetailRequestDto = CreateOptionDetailRequestDto.create(name, 20000, true);
+        optionDetailCreateService.createOptionDetail(ADMIN, createOptionDetailRequestDto, optionId);
+
+        ProductOption productOption = productOptionRepository.findById(optionId).orElseGet(null);
+        OptionDetail optiondetail = productOption.getOptionDetails().get(productOption.getOptionDetails().size() - 1);
+
+        Assertions.assertEquals(optiondetail.getName(), name);
+        Assertions.assertEquals(optiondetail.getPrice(), 20000);
+        Assertions.assertEquals(optiondetail.isOnSale(), true);
+
+        Assertions.assertThrows(ResourceNotFoundException.class, () -> optionDetailCreateService.createOptionDetail(ADMIN, createOptionDetailRequestDto, "null"));
+
+    }
 }


### PR DESCRIPTION
## 스프린트 넘버  :  8
## 메이저 마일스톤 : 관리자
### 마이너 마일스톤 : 상품 관리
### 백로그 이름 : 옵션 선택지 추가


***
### 작업

**API**
<img width="869" alt="image" src="https://github.com/Liberty52/product/assets/48744386/55fa0091-7808-4d0b-b9c6-7c899ae85818">
<img width="348" alt="image" src="https://github.com/Liberty52/product/assets/48744386/a74ada0c-ca6c-49b2-ac15-588a323e42e1">

**CODE** 
<img width="890" alt="image" src="https://github.com/Liberty52/product/assets/48744386/5a930df1-5bf0-4180-b1dc-eca6178ef1a3">


***
### 테스트 결과
<img width="1246" alt="image" src="https://github.com/Liberty52/product/assets/48744386/2b961caf-dc03-4650-a467-33d35324f7a4">


***
### 이슈
이름이 중복되는 경우가 있을 수도 있는데 그것은 현재는 관리자의 자유에 맡기는 것이 났다고 생각돼 따로 예외처리하지 않았습니다.