### PR TITLE
Lib 247 옵션 선택지 삭제

### DIFF
--- a/src/main/java/com/liberty52/product/service/applicationservice/OptionDetailRemoveService.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/OptionDetailRemoveService.java
@@ -1,2 +1,7 @@
-package com.liberty52.product.service.applicationservice.impl;public interface OptionDetailRemoveService {
+package com.liberty52.product.service.applicationservice;
+
+import com.liberty52.product.service.controller.dto.OptionDetailRemoveRequestDto;
+
+public interface OptionDetailRemoveService {
+    void removeOptionDetail(String role, String optionDetailId, OptionDetailRemoveRequestDto dto);
 }

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/OptionDetailRemoveServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/OptionDetailRemoveServiceImpl.java
@@ -1,2 +1,31 @@
-package com.liberty52.product.service.applicationservice.impl;public class OptionDetailRemoveServiceImpl {
+package com.liberty52.product.service.applicationservice.impl;
+
+import com.liberty52.product.global.exception.external.forbidden.InvalidRoleException;
+import com.liberty52.product.global.exception.external.notfound.ResourceNotFoundException;
+import com.liberty52.product.service.applicationservice.OptionDetailRemoveService;
+import com.liberty52.product.service.controller.dto.OptionDetailRemoveRequestDto;
+import com.liberty52.product.service.entity.OptionDetail;
+import com.liberty52.product.service.entity.Review;
+import com.liberty52.product.service.repository.OptionDetailRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.liberty52.product.global.contants.RoleConstants.ADMIN;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OptionDetailRemoveServiceImpl implements OptionDetailRemoveService {
+
+    private final OptionDetailRepository optionDetailRepository;
+
+    @Override
+    public void removeOptionDetail(String role, String optionDetailId, OptionDetailRemoveRequestDto dto) {
+        if(!ADMIN.equals(role)) {
+            throw new InvalidRoleException(role);
+        }
+        OptionDetail optionDetail = optionDetailRepository.findById(optionDetailId).orElseThrow(() -> new ResourceNotFoundException("OptionDetail", "ID", optionDetailId));
+        optionDetail.updateOnSale(dto.getOnSail());
+    }
 }

--- a/src/main/java/com/liberty52/product/service/controller/OptionDetailRemoveController.java
+++ b/src/main/java/com/liberty52/product/service/controller/OptionDetailRemoveController.java
@@ -1,2 +1,20 @@
-package com.liberty52.product.service.controller;public class OptionDetailRemoveController {
+package com.liberty52.product.service.controller;
+
+import com.liberty52.product.service.applicationservice.OptionDetailRemoveService;
+import com.liberty52.product.service.controller.dto.OptionDetailRemoveRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class OptionDetailRemoveController {
+    private final OptionDetailRemoveService optionDetailRemoveService;
+
+    @DeleteMapping("/optionDetail/{optionDetailId}")
+    @ResponseStatus(HttpStatus.OK)
+    public void removeOptionDetail(@RequestHeader("LB-Role") String role, @PathVariable String optionDetailId, @Validated @RequestBody OptionDetailRemoveRequestDto dto) {
+        optionDetailRemoveService.removeOptionDetail(role, optionDetailId, dto);
+    }
 }

--- a/src/main/java/com/liberty52/product/service/controller/dto/OptionDetailRemoveRequestDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/OptionDetailRemoveRequestDto.java
@@ -1,2 +1,17 @@
-package com.liberty52.product.service.controller.dto;public class OptionDetailRemoveRequestDto {
+package com.liberty52.product.service.controller.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class OptionDetailRemoveRequestDto {
+
+    @NotNull
+    Boolean onSail;
+
+    public static OptionDetailRemoveRequestDto create(boolean onSail){
+        OptionDetailRemoveRequestDto dto = new OptionDetailRemoveRequestDto();
+        dto.onSail = onSail;
+        return dto;
+    }
 }

--- a/src/main/java/com/liberty52/product/service/entity/OptionDetail.java
+++ b/src/main/java/com/liberty52/product/service/entity/OptionDetail.java
@@ -44,4 +44,8 @@ public class OptionDetail {
         this.productOption = productOption;
         this.productOption.addDetail(this);
     }
+
+    public void updateOnSale(boolean onSail) {
+        this.onSale = onSail;
+    }
 }

--- a/src/test/java/com/liberty52/product/service/applicationservice/OptionDetailRemoveServiceTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/OptionDetailRemoveServiceTest.java
@@ -1,2 +1,35 @@
-package com.liberty52.product.service.applicationservice;public class OptionDetailRemoveServiceTest {
+package com.liberty52.product.service.applicationservice;
+
+import com.liberty52.product.service.controller.dto.OptionDetailRemoveRequestDto;
+import com.liberty52.product.service.entity.OptionDetail;
+import com.liberty52.product.service.repository.OptionDetailRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.liberty52.product.global.contants.RoleConstants.ADMIN;
+
+@SpringBootTest
+@Transactional
+public class OptionDetailRemoveServiceTest {
+
+    @Autowired
+    OptionDetailRemoveService optionDetailRemoveService;
+
+    @Autowired
+    OptionDetailRepository optionDetailRepository;
+
+    @Test
+    void 옵션선택지삭제(){
+        String detailId = "OPT-002";
+        OptionDetailRemoveRequestDto dto = OptionDetailRemoveRequestDto.create(false);
+        OptionDetail beforeOptionDetail = optionDetailRepository.findById(detailId).orElseGet(null);
+        boolean onSail = beforeOptionDetail.isOnSale();
+        optionDetailRemoveService.removeOptionDetail(ADMIN, detailId, dto);
+        OptionDetail afterOptionDetail = optionDetailRepository.findById(detailId).orElseGet(null);
+        Assertions.assertEquals(afterOptionDetail.isOnSale(), !onSail);
+
+    }
 }


### PR DESCRIPTION
## 스프린트 넘버  : 8
## 메이저 마일스톤 : 관리자
### 마이너 마일스톤 : 상품관리
### 백로그 이름 : 상품 옵션 선택지 삭제


***
### 작업

**API**
<img width="739" alt="image" src="https://github.com/Liberty52/product/assets/48744386/a4d67a6d-beae-46a9-8229-146d4d39bfc8">
<img width="343" alt="image" src="https://github.com/Liberty52/product/assets/48744386/88461db6-4b33-4287-937b-38938f01054a">
dto가 수정으로 통합 될 수도 있다고 생각되어 받는 파라미터가 하나임에도 dto 안에 넣었다

**CODE** 
<img width="903" alt="image" src="https://github.com/Liberty52/product/assets/48744386/7e75782a-5f55-468b-8fc2-8869fd166d19">


***
### 테스트 결과

<img width="1246" alt="image" src="https://github.com/Liberty52/product/assets/48744386/a33d89f5-c016-40bf-ad22-26c61a1b1005">

***
### 이슈
