### PR TITLE
issue171 해결 이미지를 s3 저장 후 반환

### DIFF
--- a/src/main/java/com/liberty52/product/global/adapter/s3/S3Uploader.java
+++ b/src/main/java/com/liberty52/product/global/adapter/s3/S3Uploader.java
@@ -5,4 +5,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface S3Uploader extends S3Uploader_ {
     String upload(MultipartFile multipartFile) throws S3UploaderException;
+
+    String uploadOfByte(byte[] b);
 }

--- a/src/main/java/com/liberty52/product/global/adapter/s3/S3UploaderImpl.java
+++ b/src/main/java/com/liberty52/product/global/adapter/s3/S3UploaderImpl.java
@@ -3,6 +3,7 @@ package com.liberty52.product.global.adapter.s3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.liberty52.product.global.exception.internal.FileConvertException;
 import com.liberty52.product.global.exception.internal.FileNullException;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.ion.NullValueException;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -44,6 +46,17 @@ public class S3UploaderImpl implements S3Uploader {
         } catch (IOException e) {
             throw new S3UploaderException();
         }
+    }
+
+    @Override
+    public String uploadOfByte(byte[] b) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(b.length);
+        metadata.setContentType("image/png");
+        String fileName = customProductPath + "/" + UUID.randomUUID() + ".png";
+        amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, new ByteArrayInputStream(b), metadata)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+        return amazonS3Client.getUrl(bucket, fileName).toString();
     }
 
     @Override

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/ImageGenerationServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/ImageGenerationServiceImpl.java
@@ -1,31 +1,34 @@
 package com.liberty52.product.service.applicationservice.impl;
 
 import com.liberty52.product.global.adapter.DallEApiClient;
+import com.liberty52.product.global.adapter.s3.S3Uploader;
 import com.liberty52.product.service.applicationservice.ImageGenerationService;
 import com.liberty52.product.service.controller.dto.ImageGenerationDto;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.codec.binary.Base64;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ImageGenerationServiceImpl implements ImageGenerationService {
     private final DallEApiClient dallEApiClient;
+    private final S3Uploader s3Uploader;
+
     @Override
     public ImageGenerationDto.Response generate(String authId, ImageGenerationDto.Request dto) {
         List<String> urls = dallEApiClient
-                .generateImage(dto.prompt(),
+                .generateImageAsB64Json(dto.prompt(),
                         dto.n(),
                         DallEApiClient.Dto.Request.Size.S1024,
-                        DallEApiClient.Dto.Request.Format.URL,
                         authId)
-                .data()
+                .getData()
                 .stream()
-                .map(DallEApiClient.Dto.Response.GenerationData::url)
+                .map(DallEApiClient.Dto.Response.Data.B64Json::getB64Json)
+                .map(Base64::decodeBase64)
+                .map(s3Uploader::uploadOfByte)
                 .toList();
-
         return new ImageGenerationDto.Response(urls);
     }
 }

--- a/src/test/java/com/liberty52/product/global/adapter/portone/webclient/DallEApiClientTest.java
+++ b/src/test/java/com/liberty52/product/global/adapter/portone/webclient/DallEApiClientTest.java
@@ -9,16 +9,25 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest
 class DallEApiClientTest {
-    @Autowired
-    DallEApiClient client;
-    @Test
-    void generateImage() {
-        DallEApiClient.Dto.Response response = client.generateImage("Imagine a beautiful landscape with vibrant colors and serene atmosphere.",
-                1,
-                DallEApiClient.Dto.Request.Size.S256,
-                DallEApiClient.Dto.Request.Format.URL,
-                "user");
-        assertNotNull(response);
-    }
+    // 필요할 때만 테스트. 비용..
+//    @Autowired
+//    DallEApiClient client;
+//    @Test
+//    void generateImage() {
+//        DallEApiClient.Dto.Response<?> response = client.generateImageAsUrl("Imagine a beautiful landscape with vibrant colors and serene atmosphere.",
+//                1,
+//                DallEApiClient.Dto.Request.Size.S256,
+//                "user");
+//        assertNotNull(response);
+//    }
+//
+//    @Test
+//    void generateImageAsB64() {
+//        DallEApiClient.Dto.Response.B64Json response = client.generateImageAsB64Json("Imagine a beautiful landscape with vibrant colors and serene atmosphere.",
+//                1,
+//                DallEApiClient.Dto.Request.Size.S256,
+//                "user");
+//        assertNotNull(response);
+//    }
 
 }


### PR DESCRIPTION
## 이슈 넘버  : #171 


***
### 작업
DallEApiClient 리팩터링

ImageGenerationService로직 변경
기존: OpenAi API가 자체적으로 이미지 저장 후 URL 반환. 그대로 전다.
변경: OpenAi API가 자체적으로 이미지 저장하지 않고 b64 인코딩 이미지 응답. S3 업로드 후 반환 


비용 발생하는 테스트 주석 처리

**CODE** 
```java
// 서비스 로직 수정
    @Override
    public ImageGenerationDto.Response generate(String authId, ImageGenerationDto.Request dto) {
        List<String> urls = dallEApiClient
                .generateImageAsB64Json(dto.prompt(),
                        dto.n(),
                        DallEApiClient.Dto.Request.Size.S1024,
                        authId)
                .getData()
                .stream()
                .map(DallEApiClient.Dto.Response.Data.B64Json::getB64Json)
                .map(Base64::decodeBase64)
                .map(s3Uploader::uploadOfByte)
                .toList();
        return new ImageGenerationDto.Response(urls);
    }
```

```java
// S3Uploader 메서드 추가
    @Override
    public String uploadOfByte(byte[] b) {
        ObjectMetadata metadata = new ObjectMetadata();
        metadata.setContentLength(b.length);
        metadata.setContentType("image/png");
        String fileName = customProductPath + "/" + UUID.randomUUID() + ".png";
        amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, new ByteArrayInputStream(b), metadata)
                .withCannedAcl(CannedAccessControlList.PublicRead));
        return amazonS3Client.getUrl(bucket, fileName).toString();
    }
```


***
### 테스트 결과
포스트맨으로 확인.
S3 저장 확인.
![image](https://github.com/Liberty52/product/assets/74762475/cc41d640-2a7a-4803-80a0-0521284e6429)


### 리뷰 요청
![image](https://github.com/Liberty52/product/assets/74762475/8e071edd-7b6d-4676-b12f-e41818ab6e37)