### PR TITLE
ISSUE-202 주문취소 데이터 시간 포맷팅

### DIFF
--- a/src/main/java/com/liberty52/product/global/util/Utils.java
+++ b/src/main/java/com/liberty52/product/global/util/Utils.java
@@ -2,9 +2,13 @@ package com.liberty52.product.global.util;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 
 public class Utils {
+
+    public static DateTimeFormatter DATE_FORMAT_CUSTOM = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
     public static LocalDateTime convertUnixToLocalDateTime(long unixTime) {
         return LocalDateTime.ofEpochSecond(unixTime, 0, ZoneOffset.UTC);
     }

--- a/src/main/java/com/liberty52/product/service/controller/dto/AdminCanceledOrderDetailResponse.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/AdminCanceledOrderDetailResponse.java
@@ -1,5 +1,6 @@
 package com.liberty52.product.service.controller.dto;
 
+import com.liberty52.product.global.util.Utils;
 import com.liberty52.product.service.entity.Orders;
 import lombok.*;
 
@@ -31,9 +32,9 @@ public class AdminCanceledOrderDetailResponse {
         public static CanceledOrderDetailResponse of(Orders order) {
             CanceledOrderDetailResponse response = new CanceledOrderDetailResponse();
             response.reason = order.getCanceledOrders().getReason();
-            response.reqAt = order.getCanceledOrders().getReqAt().toString();
+            response.reqAt = order.getCanceledOrders().getReqAt().format(Utils.DATE_FORMAT_CUSTOM);
             response.canceledAt = order.getCanceledOrders().getCanceledAt() != null ?
-                    order.getCanceledOrders().getCanceledAt().toString() : "대기중";
+                    order.getCanceledOrders().getCanceledAt().format(Utils.DATE_FORMAT_CUSTOM) : "대기중";
             response.fee = order.getCanceledOrders().getFee();
             response.approvedAdminName = order.getCanceledOrders().getApprovedAdminName();
             return response;

--- a/src/main/java/com/liberty52/product/service/controller/dto/AdminCanceledOrderListResponse.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/AdminCanceledOrderListResponse.java
@@ -1,6 +1,7 @@
 package com.liberty52.product.service.controller.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.liberty52.product.global.util.Utils;
 import com.liberty52.product.service.entity.Orders;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -66,9 +67,9 @@ public class AdminCanceledOrderListResponse {
             response.orderDate = entity.getOrderDate().toString();
             response.customerId = entity.getAuthId();
             response.orderStatus = entity.getOrderStatus().name();
-            response.reqAt = entity.getCanceledOrders().getReqAt().toString();
+            response.reqAt = entity.getCanceledOrders().getReqAt().format(Utils.DATE_FORMAT_CUSTOM);
             response.canceledAt = entity.getCanceledOrders().getCanceledAt() != null ?
-                    entity.getCanceledOrders().getCanceledAt().toString() : "대기중";
+                    entity.getCanceledOrders().getCanceledAt().format(Utils.DATE_FORMAT_CUSTOM) : "대기중";
             response.approvedAdminName = entity.getCanceledOrders().getApprovedAdminName();
             return response;
         }


### PR DESCRIPTION
***
### 작업

주문 취소 데이터 시간 포맷팅을 변경한 이슈.

기존 주문취소 데이터는 기본 LocalDateTime의 포맷팅인 `yyyy-MM-dd'T'HH:mm:ss`인데,  
이를 `yyyy-MM-dd HH:mm`으로 변경함.

***
### 테스트 결과
빌드 테스트 🟢 
![image](https://github.com/Liberty52/product/assets/42243302/661585e6-3f08-4ad6-86ea-66f78e58584c)

API 테스트 🟢 
![image](https://github.com/Liberty52/product/assets/42243302/7cba364f-60af-415b-a19c-5b645c8d2e15)

![image](https://github.com/Liberty52/product/assets/42243302/963a71f2-fe4f-4abe-9257-3c821c4c8d3e)

