### PR TITLE
(관리자) 상품 소개 관리 수정

### DIFF
--- a/src/main/java/com/liberty52/product/service/applicationservice/ProductIntroductionModifyService.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/ProductIntroductionModifyService.java
@@ -1,0 +1,7 @@
+package com.liberty52.product.service.applicationservice;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ProductIntroductionModifyService {
+    void modifyProductIntroduction(String role, String productId, MultipartFile productIntroductionImageFile);
+}

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/ProductIntroductionModifyServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/ProductIntroductionModifyServiceImpl.java
@@ -1,0 +1,37 @@
+package com.liberty52.product.service.applicationservice.impl;
+
+import com.liberty52.product.global.adapter.s3.S3UploaderApi;
+import com.liberty52.product.global.exception.external.notfound.ResourceNotFoundException;
+import com.liberty52.product.global.util.Validator;
+import com.liberty52.product.service.applicationservice.ProductIntroductionModifyService;
+import com.liberty52.product.service.entity.Product;
+import com.liberty52.product.service.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProductIntroductionModifyServiceImpl implements ProductIntroductionModifyService {
+    private final ProductRepository productRepository;
+    private final S3UploaderApi s3Uploader;
+
+    @Override
+    public void modifyProductIntroduction(String role, String productId, MultipartFile productIntroductionImageFile) {
+        Validator.isAdmin(role);
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new ResourceNotFoundException("Product", "ID", productId));
+        if (productIntroductionImageFile != null) {
+            //delete previous image
+            String previousImageUrl = product.getProductIntroductionImageUrl();
+            if(previousImageUrl!=null) s3Uploader.delete(previousImageUrl);
+            //upload new image
+            String imageUrl = s3Uploader.upload(productIntroductionImageFile);
+            product.createProductIntroduction(imageUrl);
+        }
+        productRepository.save(product);
+    }
+}

--- a/src/main/java/com/liberty52/product/service/controller/ProductIntroductionModifyController.java
+++ b/src/main/java/com/liberty52/product/service/controller/ProductIntroductionModifyController.java
@@ -1,0 +1,22 @@
+package com.liberty52.product.service.controller;
+
+
+import com.liberty52.product.service.applicationservice.ProductIntroductionModifyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+public class ProductIntroductionModifyController {
+    private final ProductIntroductionModifyService productIntroductionModifyService;
+
+    @PatchMapping("/admin/product/{productId}/introduction")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void modifyProductIntroductionByAdmin(@RequestHeader("LB-Role") String role, @PathVariable String productId,
+                                                 @RequestPart(value = "images",required = false) MultipartFile productIntroductionImageFile){
+            productIntroductionModifyService.modifyProductIntroduction(role, productId, productIntroductionImageFile);
+    }
+
+}

--- a/src/test/java/com/liberty52/product/service/applicationservice/mock/ProductIntroductionModifyMockTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/mock/ProductIntroductionModifyMockTest.java
@@ -1,0 +1,54 @@
+package com.liberty52.product.service.applicationservice.mock;
+
+
+import com.liberty52.product.global.adapter.s3.S3UploaderApi;
+import com.liberty52.product.global.exception.internal.S3UploaderException;
+import com.liberty52.product.service.applicationservice.impl.ProductIntroductionModifyServiceImpl;
+import com.liberty52.product.service.entity.Product;
+import com.liberty52.product.service.entity.ProductState;
+import com.liberty52.product.service.repository.ProductRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Optional;
+
+import static com.liberty52.product.global.constants.RoleConstants.ADMIN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ProductIntroductionModifyMockTest {
+    @InjectMocks
+    ProductIntroductionModifyServiceImpl productIntroductionModifyService;
+
+    @Mock
+    ProductRepository productRepository;
+
+    @Mock
+    S3UploaderApi s3Uploader;
+
+    @Test
+    void 제품소개수정() throws S3UploaderException {
+        /**Given**/
+        String productId = "testProductId";
+        MultipartFile multipartFile = mock(MultipartFile.class);
+        //generate testProduct
+        Product testProduct = Product.builder().name("test").productState(ProductState.ON_SALE).price(0L).build();
+        //assume that testProduct has previous image
+        testProduct.createProductIntroduction("previousMockImageUrl");
+
+        when(productRepository.findById(productId)).thenReturn(Optional.of(testProduct));
+        when(s3Uploader.upload(multipartFile)).thenReturn("newMockImageUrl");
+
+        /**When**/
+        productIntroductionModifyService.modifyProductIntroduction(ADMIN, productId, multipartFile);
+
+        /**Then**/
+        assertEquals("newMockImageUrl", testProduct.getProductIntroductionImageUrl());
+    }
+
+}


### PR DESCRIPTION
### 백로그 이름 : 상품 소개 관리 수정 ( 관리자 )


***
### 작업
상품 소개 관리 수정 API 및 테스트코드 작성
 
**API**
```
PATCH admin/product/{productId}/introduction

REQUEST 
Headers: {
  LB-Role: role
}

Data: {
  "images": MultipartFile (required = false)
}

RESPONSE
Status: 
  204: 수정 성공
  404: productId에 해당하는 Product가 없음

```
**CODE** 


***
### 테스트 결과
<img width="613" alt="image" src="https://github.com/Liberty52/product/assets/96376539/21dd688f-2b94-43bc-bba2-318f8af4de6c">


***
### 이슈
우선 박찬길 팀원과 상의해서 요청 데이터는 사진 1장으로 결정, 텍스트 & 사진 여러장으로 변경할지에 대해서는 향후 추가적으로 의논 후에 수정하는 방향으로 결정했습니다.