### PR TITLE
상품 소개 관리 수정 - 삭제기능, 테스트케이스 추가

### DIFF
--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/ProductIntroductionModifyServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/ProductIntroductionModifyServiceImpl.java
@@ -24,14 +24,15 @@ public class ProductIntroductionModifyServiceImpl implements ProductIntroduction
         Validator.isAdmin(role);
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new ResourceNotFoundException("Product", "ID", productId));
-        if (productIntroductionImageFile != null) {
-            //delete previous image
-            String previousImageUrl = product.getProductIntroductionImageUrl();
-            if(previousImageUrl!=null) s3Uploader.delete(previousImageUrl);
-            //upload new image
-            String imageUrl = s3Uploader.upload(productIntroductionImageFile);
-            product.createProductIntroduction(imageUrl);
-        }
+
+        //delete previous image
+        String previousImageUrl = product.getProductIntroductionImageUrl();
+        if(previousImageUrl!=null) s3Uploader.delete(previousImageUrl);
+        String imageUrl = null;
+        //upload new image
+        if (productIntroductionImageFile != null) imageUrl = s3Uploader.upload(productIntroductionImageFile);
+        product.createProductIntroduction(imageUrl);
+
         productRepository.save(product);
     }
 }

--- a/src/test/java/com/liberty52/product/service/applicationservice/mock/ProductIntroductionModifyMockTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/mock/ProductIntroductionModifyMockTest.java
@@ -33,6 +33,7 @@ public class ProductIntroductionModifyMockTest {
 
     @Test
     void 제품소개수정() throws S3UploaderException {
+        /*-----------<Test Case 1(prev image->new image)>-----------*/
         /**Given**/
         String productId = "testProductId";
         MultipartFile multipartFile = mock(MultipartFile.class);
@@ -49,6 +50,39 @@ public class ProductIntroductionModifyMockTest {
 
         /**Then**/
         assertEquals("newMockImageUrl", testProduct.getProductIntroductionImageUrl());
+
+        /*-----------<Test Case 2(image -> no image)>-----------*/
+        /**Given**/
+        String product2Id = "testProductId2";
+        Product testProduct2 = Product.builder().name("test2").productState(ProductState.ON_SALE).price(0L).build();
+        //assume that testProduct has previous image
+        testProduct2.createProductIntroduction("previousMockImageUrl");
+
+        when(productRepository.findById(product2Id)).thenReturn(Optional.of(testProduct2));
+
+        /**When**/
+        productIntroductionModifyService.modifyProductIntroduction(ADMIN, product2Id, null);
+
+        /**Then**/
+        assertEquals(null, testProduct2.getProductIntroductionImageUrl());
+
+        /*-----------<Test Case 3(no image -> new image)>-----------*/
+        /**Given**/
+        String product3Id = "testProductId2";
+        MultipartFile multipartFile3 = mock(MultipartFile.class);
+        Product testProduct3 = Product.builder().name("test3").productState(ProductState.ON_SALE).price(0L).build();
+        //assume that testProduct has no previous image
+        testProduct2.createProductIntroduction("null");
+
+        when(productRepository.findById(product3Id)).thenReturn(Optional.of(testProduct3));
+        when(s3Uploader.upload(multipartFile3)).thenReturn("newMockImageUrl");
+
+        /**When**/
+        productIntroductionModifyService.modifyProductIntroduction(ADMIN, product3Id, multipartFile3);
+
+        /**Then**/
+        assertEquals("newMockImageUrl", testProduct3.getProductIntroductionImageUrl());
+
     }
 
 }


### PR DESCRIPTION
### 백로그 이름 : 상품 소개 관리 수정 ( 관리자 )


***
### 작업
수정 기능에서 삭제 기능도 함께 기능하도록 코드를 일부 변경했습니다.
이에 따라 테스트케이스도 아래와 같이 세분화하였습니다.
1. 기존 이미지 존재하는 상태 -> 새 이미지로 수정
2. 기존 이미지 존재하는 상태 -> 이미지 삭제
3. 기존 이미지 없는 상태 -> 새 이미지로 수정 (이거는 프론트 단에서 찬길님이 만드신 post api를 호출하게 설정해놓아 발생할 가능성이 없는 케이스지만, 일단 추가해놓음)

***
### 테스트 결과
<img width="768" alt="image" src="https://github.com/Liberty52/product/assets/96376539/cf6b124c-7c8d-4aec-b63b-125e9419e643">


***
### 이슈
none