### PR TITLE
[관리자] 상품 옵션 선택지 재고량 수정 기능

### DIFF
--- a/src/main/java/com/liberty52/product/global/config/DBInitConfig.java
+++ b/src/main/java/com/liberty52/product/global/config/DBInitConfig.java
@@ -73,14 +73,14 @@ public class DBInitConfig {
                 option1.associate(product);
                 productOptionRepository.save(option1);
 
-                OptionDetail detailEasel = OptionDetail.create("이젤 거치형", 100,true);
+                OptionDetail detailEasel = OptionDetail.create("이젤 거치형", 100,true, 100);
                 detailEasel.associate(option1);
                 Field detailEaselId = detailEasel.getClass().getDeclaredField("id");
                 detailEaselId.setAccessible(true);
                 detailEaselId.set(detailEasel, "OPT-001");
                 optionDetailRepository.save(detailEasel);
 
-                OptionDetail detailWall = OptionDetail.create("벽걸이형", 100,true);
+                OptionDetail detailWall = OptionDetail.create("벽걸이형", 100,true, 100);
                 detailWall.associate(option1);
                 Field detailWallId = detailWall.getClass().getDeclaredField("id");
                 detailWallId.setAccessible(true);
@@ -91,7 +91,7 @@ public class DBInitConfig {
                 option2.associate(product);
                 productOptionRepository.save(option2);
 
-                OptionDetail material = OptionDetail.create("1mm 두께 승화전사 인쇄용 알루미늄시트", 100,true);
+                OptionDetail material = OptionDetail.create("1mm 두께 승화전사 인쇄용 알루미늄시트", 100,true, 100);
                 material.associate(option2);
                 Field materialId = material.getClass().getDeclaredField("id");
                 materialId.setAccessible(true);
@@ -102,22 +102,22 @@ public class DBInitConfig {
                 option3.associate(product);
                 productOptionRepository.save(option3);
 
-                OptionDetail materialOption1 = OptionDetail.create("유광실버", 100,true);
+                OptionDetail materialOption1 = OptionDetail.create("유광실버", 100,true, 100);
                 materialOption1.associate(option3);
                 Field materialOption1Id = materialOption1.getClass().getDeclaredField("id");
                 materialOption1Id.setAccessible(true);
                 materialOption1Id.set(materialOption1, "OPT-004");
                 optionDetailRepository.save(materialOption1);
 
-                OptionDetail materialOption2 = OptionDetail.create("무광실버", 100,true);
+                OptionDetail materialOption2 = OptionDetail.create("무광실버", 100,true, 100);
                 materialOption2.associate(option3);
                 optionDetailRepository.save(materialOption2);
 
-                OptionDetail materialOption3 = OptionDetail.create("유광백색", 100,true);
+                OptionDetail materialOption3 = OptionDetail.create("유광백색", 100,true, 100);
                 materialOption3.associate(option3);
                 optionDetailRepository.save(materialOption3);
 
-                OptionDetail materialOption4 = OptionDetail.create("무광백색", 100,true);
+                OptionDetail materialOption4 = OptionDetail.create("무광백색", 100,true, 100);
                 materialOption4.associate(option3);
                 optionDetailRepository.save(materialOption4);
 

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/OptionDetailCreateServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/OptionDetailCreateServiceImpl.java
@@ -24,7 +24,7 @@ public class OptionDetailCreateServiceImpl implements OptionDetailCreateService 
     public void createOptionDetailByAdmin(String role, CreateOptionDetailRequestDto dto, String optionId) {
         Validator.isAdmin(role);
         ProductOption productOption = productOptionRepository.findById(optionId).orElseThrow(() -> new ResourceNotFoundException("option", "id", optionId));
-        OptionDetail optionDetail = OptionDetail.create(dto.getName(), dto.getPrice(), dto.getOnSale());
+        OptionDetail optionDetail = OptionDetail.create(dto.getName(), dto.getPrice(), dto.getOnSale(), 0);
         optionDetail.associate(productOption);
         optionDetailRepository.save(optionDetail);
     }

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/OptionDetailModifyServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/OptionDetailModifyServiceImpl.java
@@ -21,13 +21,12 @@ public class OptionDetailModifyServiceImpl implements OptionDetailModifyService 
     public void modifyOptionDetailByAdmin(String role, String optionDetailId, OptionDetailModifyRequestDto dto) {
         Validator.isAdmin(role);
         OptionDetail optionDetail = optionDetailRepository.findById(optionDetailId).orElseThrow(() -> new ResourceNotFoundException("OptionDetail", "ID", optionDetailId));
-        optionDetail.modify(dto.getName(), dto.getPrice(), dto.getOnSale());
+        optionDetail.modify(dto.getName(), dto.getPrice(), dto.getOnSale(), dto.getStock());
     }
 
     public void modifyOptionDetailOnSailStateByAdmin(String role, String optionDetailId) {
         Validator.isAdmin(role);
         OptionDetail optionDetail = optionDetailRepository.findById(optionDetailId).orElseThrow(() -> new ResourceNotFoundException("OptionDetail", "ID", optionDetailId));
         optionDetail.updateOnSale();
-
     }
 }

--- a/src/main/java/com/liberty52/product/service/controller/dto/CreateOptionDetailRequestDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/CreateOptionDetailRequestDto.java
@@ -1,5 +1,6 @@
 package com.liberty52.product.service.controller.dto;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -11,6 +12,7 @@ public class CreateOptionDetailRequestDto {
     String name;
 
     @NotNull
+    @Min(0)
     Integer price;
 
     @NotNull

--- a/src/main/java/com/liberty52/product/service/controller/dto/OptionDetailModifyRequestDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/OptionDetailModifyRequestDto.java
@@ -20,9 +20,11 @@ public class OptionDetailModifyRequestDto {
     @NotNull
     Boolean onSale;
 
-    public static OptionDetailModifyRequestDto create(String name, int price, boolean onSale){
-        return new OptionDetailModifyRequestDto(name, price, onSale);
-    }
+    @NotNull
+    Integer stock;
 
+    public static OptionDetailModifyRequestDto create(String name, int price, boolean onSale, Integer stock){
+        return new OptionDetailModifyRequestDto(name, price, onSale, stock);
+    }
 
 }

--- a/src/main/java/com/liberty52/product/service/controller/dto/OptionDetailModifyRequestDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/OptionDetailModifyRequestDto.java
@@ -1,5 +1,6 @@
 package com.liberty52.product.service.controller.dto;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -15,12 +16,14 @@ public class OptionDetailModifyRequestDto {
     String name;
 
     @NotNull
+    @Min(0)
     Integer price;
 
     @NotNull
     Boolean onSale;
 
     @NotNull
+    @Min(0)
     Integer stock;
 
     public static OptionDetailModifyRequestDto create(String name, int price, boolean onSale, Integer stock){

--- a/src/main/java/com/liberty52/product/service/controller/dto/ProductOptionDetailResponseDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/ProductOptionDetailResponseDto.java
@@ -14,12 +14,14 @@ public class ProductOptionDetailResponseDto {
     String optionDetailName;
     int price;
     boolean onSale;
+    Integer stock;
 
     public ProductOptionDetailResponseDto(OptionDetail optionDetail) {
          optionDetailId = optionDetail.getId();
          optionDetailName = optionDetail.getName();
          price = optionDetail.getPrice();
          onSale = optionDetail.isOnSale();
+         stock = optionDetail.getStock();
     }
 
 }

--- a/src/main/java/com/liberty52/product/service/entity/OptionDetail.java
+++ b/src/main/java/com/liberty52/product/service/entity/OptionDetail.java
@@ -29,15 +29,19 @@ public class OptionDetail {
     @Column(nullable = false)
     private boolean onSale;
 
+    @Column(nullable = false)
+    private Integer stock;
+
     @Builder
-    private OptionDetail(String name, Integer price, boolean onSale) {
+    private OptionDetail(String name, Integer price, boolean onSale, Integer stock) {
         this.name = name;
         this.price = price;
         this.onSale = onSale;
+        this.stock = stock;
     }
 
-    public static OptionDetail create(String name, Integer price, boolean onSale) {
-        return builder().name(name).price(price).onSale(onSale).build();
+    public static OptionDetail create(String name, Integer price, boolean onSale, Integer stock) {
+        return builder().name(name).price(price).onSale(onSale).stock(stock).build();
     }
 
     public void associate(ProductOption productOption) {
@@ -49,9 +53,10 @@ public class OptionDetail {
         onSale = !onSale;
     }
 
-    public void modify(String name, Integer price, Boolean onSail) {
+    public void modify(String name, Integer price, Boolean onSail, Integer stock) {
         this.name = name;
         this.price = price;
         this.onSale = onSail;
+        this.stock = stock;
     }
 }

--- a/src/test/java/com/liberty52/product/service/applicationservice/OptionDetailModifyServiceTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/OptionDetailModifyServiceTest.java
@@ -13,7 +13,7 @@ import static com.liberty52.product.global.constants.RoleConstants.ADMIN;
 
 @SpringBootTest
 @Transactional
-public class OptionDetailModifyTest {
+public class OptionDetailModifyServiceTest {
 
     @Autowired
     OptionDetailModifyService optionDetailModifyService;
@@ -38,14 +38,16 @@ public class OptionDetailModifyTest {
         String detailId = "OPT-002";
         String name = "테스트";
         int price = 3;
+        int stock = 100;
         OptionDetail beforeOptionDetail = optionDetailRepository.findById(detailId).orElse(null);
         boolean onSail = beforeOptionDetail.isOnSale();
 
-        OptionDetailModifyRequestDto dto = OptionDetailModifyRequestDto.create(name,price,!onSail);
+        OptionDetailModifyRequestDto dto = OptionDetailModifyRequestDto.create(name,price,!onSail,stock);
         optionDetailModifyService.modifyOptionDetailByAdmin(ADMIN, detailId, dto);
         OptionDetail afterOptionDetail = optionDetailRepository.findById(detailId).orElse(null);
         Assertions.assertEquals(afterOptionDetail.isOnSale(), !onSail);
         Assertions.assertEquals(afterOptionDetail.getName(), name);
         Assertions.assertEquals(afterOptionDetail.getPrice(), price);
+        Assertions.assertEquals(afterOptionDetail.getStock(), stock);
     }
 }

--- a/src/test/java/com/liberty52/product/service/applicationservice/mock/CartItemCreateServiceMockTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/mock/CartItemCreateServiceMockTest.java
@@ -77,10 +77,10 @@ public class CartItemCreateServiceMockTest extends MockS3Test {
         given(customProductRepository.save(any())).willReturn(null);
         given(customProductOptionRepository.save(any())).willReturn(null);
 
-        given(optionDetailRepository.findByName("이젤 거치형")).willReturn(Optional.ofNullable(OptionDetail.create("이젤 거치형", 100, true)));
-        given(optionDetailRepository.findByName("1mm 두께 승화전사 인쇄용 알루미늄시트")).willReturn(Optional.ofNullable(OptionDetail.create("1mm 두께 승화전사 인쇄용 알루미늄시트", 100, true)));
-        given(optionDetailRepository.findByName("무광실버")).willReturn(Optional.ofNullable(OptionDetail.create("무광실버", 100, true)));
-        given(optionDetailRepository.findByName("벽걸이형")).willReturn(Optional.ofNullable(OptionDetail.create("벽걸이형", 100, true)));
+        given(optionDetailRepository.findByName("이젤 거치형")).willReturn(Optional.ofNullable(OptionDetail.create("이젤 거치형", 100, true, 100)));
+        given(optionDetailRepository.findByName("1mm 두께 승화전사 인쇄용 알루미늄시트")).willReturn(Optional.ofNullable(OptionDetail.create("1mm 두께 승화전사 인쇄용 알루미늄시트", 100, true, 100)));
+        given(optionDetailRepository.findByName("무광실버")).willReturn(Optional.ofNullable(OptionDetail.create("무광실버", 100, true, 100)));
+        given(optionDetailRepository.findByName("벽걸이형")).willReturn(Optional.ofNullable(OptionDetail.create("벽걸이형", 100, true, 100)));
 
         //when
         cartItemCreateService.createAuthCartItem("testId", imageFile, dto1);

--- a/src/test/java/com/liberty52/product/service/applicationservice/mock/CartItemRetrieveServiceMockTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/mock/CartItemRetrieveServiceMockTest.java
@@ -53,25 +53,25 @@ public class CartItemRetrieveServiceMockTest extends MockS3Test {
 
         ProductOption option1 = ProductOption.create("거치 방식", true, true);
         option1.associate(product);
-        OptionDetail detailEasel = OptionDetail.create("이젤 거치형", 100,true);
+        OptionDetail detailEasel = OptionDetail.create("이젤 거치형", 100,true,100);
         detailEasel.associate(option1);
-        OptionDetail detailWall = OptionDetail.create("벽걸이형", 100,true);
+        OptionDetail detailWall = OptionDetail.create("벽걸이형", 100,true,100);
         detailWall.associate(option1);
 
         ProductOption option2 = ProductOption.create("기본소재", true, true);
         option2.associate(product);
-        OptionDetail material = OptionDetail.create("1mm 두께 승화전사 인쇄용 알루미늄시트", 100,true);
+        OptionDetail material = OptionDetail.create("1mm 두께 승화전사 인쇄용 알루미늄시트", 100,true,100);
         material.associate(option2);
 
         ProductOption option3 = ProductOption.create("기본소재 옵션", true, true);
         option3.associate(product);
-        OptionDetail materialOption1 = OptionDetail.create("유광실버", 100,true);
+        OptionDetail materialOption1 = OptionDetail.create("유광실버", 100,true, 100);
         materialOption1.associate(option3);
-        OptionDetail materialOption2 = OptionDetail.create("무광실버", 100,true);
+        OptionDetail materialOption2 = OptionDetail.create("무광실버", 100,true, 100);
         materialOption2.associate(option3);
-        OptionDetail materialOption3 = OptionDetail.create("유광백색", 100,true);
+        OptionDetail materialOption3 = OptionDetail.create("유광백색", 100,true, 100);
         materialOption3.associate(option3);
-        OptionDetail materialOption4 = OptionDetail.create("무광백색", 100,true);
+        OptionDetail materialOption4 = OptionDetail.create("무광백색", 100,true, 100);
         materialOption4.associate(option3);
 
         // Add Cart & CartItems

--- a/src/test/java/com/liberty52/product/service/applicationservice/mock/CartItemSchedulerServiceMockTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/mock/CartItemSchedulerServiceMockTest.java
@@ -67,25 +67,25 @@ public class CartItemSchedulerServiceMockTest extends MockS3Test {
 
         ProductOption option1 = ProductOption.create("거치 방식", true, true);
         option1.associate(product);
-        OptionDetail detailEasel = OptionDetail.create("이젤 거치형", 100,true);
+        OptionDetail detailEasel = OptionDetail.create("이젤 거치형", 100,true,100);
         detailEasel.associate(option1);
-        OptionDetail detailWall = OptionDetail.create("벽걸이형", 100,true);
+        OptionDetail detailWall = OptionDetail.create("벽걸이형", 100,true,100);
         detailWall.associate(option1);
 
         ProductOption option2 = ProductOption.create("기본소재", true, true);
         option2.associate(product);
-        OptionDetail material = OptionDetail.create("1mm 두께 승화전사 인쇄용 알루미늄시트", 100,true);
+        OptionDetail material = OptionDetail.create("1mm 두께 승화전사 인쇄용 알루미늄시트", 100,true,100);
         material.associate(option2);
 
         ProductOption option3 = ProductOption.create("기본소재 옵션", true, true);
         option3.associate(product);
-        OptionDetail materialOption1 = OptionDetail.create("유광실버", 100,true);
+        OptionDetail materialOption1 = OptionDetail.create("유광실버", 100,true,100);
         materialOption1.associate(option3);
-        OptionDetail materialOption2 = OptionDetail.create("무광실버", 100,true);
+        OptionDetail materialOption2 = OptionDetail.create("무광실버", 100,true,100);
         materialOption2.associate(option3);
-        OptionDetail materialOption3 = OptionDetail.create("유광백색", 100,true);
+        OptionDetail materialOption3 = OptionDetail.create("유광백색", 100,true,100);
         materialOption3.associate(option3);
-        OptionDetail materialOption4 = OptionDetail.create("무광백색", 100,true);
+        OptionDetail materialOption4 = OptionDetail.create("무광백색", 100,true,100);
         materialOption4.associate(option3);
 
         // Add Cart & CartItems

--- a/src/test/java/com/liberty52/product/service/applicationservice/mock/OptionDetailModifyServiceMockTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/mock/OptionDetailModifyServiceMockTest.java
@@ -1,0 +1,58 @@
+package com.liberty52.product.service.applicationservice.mock;
+
+import com.liberty52.product.global.exception.internal.S3UploaderException;
+import com.liberty52.product.service.applicationservice.impl.OptionDetailModifyServiceImpl;
+import com.liberty52.product.service.controller.dto.OptionDetailModifyRequestDto;
+import com.liberty52.product.service.entity.OptionDetail;
+import com.liberty52.product.service.repository.OptionDetailRepository;
+import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.liberty52.product.global.constants.RoleConstants.ADMIN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class OptionDetailModifyServiceMockTest {
+    @InjectMocks
+    OptionDetailModifyServiceImpl optionDetailModifyService;
+
+    @Mock
+    OptionDetailRepository optionDetailRepository;
+
+    @Test
+    void 옵션선택지수정() {
+        /**Given**/
+        //generate testProductOptionDetail Entity
+        OptionDetail testOptionDetail = mock(OptionDetail.class);
+
+        //generate testProductOptionDetail Request DTO
+        String newName = "newName";
+        Integer newPrice = 1000;
+        Integer newStock = 100;
+        OptionDetailModifyRequestDto testOptionDetailModifyRequestDto = OptionDetailModifyRequestDto.create(newName,newPrice,true,newStock);
+
+        String testOptionDetailID = testOptionDetail.getId();
+        when(optionDetailRepository.findById(testOptionDetailID)).thenReturn(Optional.of(testOptionDetail));
+        when(testOptionDetail.getName()).thenReturn(newName);
+        when(testOptionDetail.getPrice()).thenReturn(newPrice);
+        when(testOptionDetail.isOnSale()).thenReturn(true);
+        when(testOptionDetail.getStock()).thenReturn(newStock);
+
+        /**When**/
+        optionDetailModifyService.modifyOptionDetailByAdmin(ADMIN, testOptionDetailID, testOptionDetailModifyRequestDto);
+
+        /**Then**/
+        assertEquals(newName, testOptionDetail.getName());
+        assertEquals(newPrice, testOptionDetail.getPrice());
+        assertEquals(true, testOptionDetail.isOnSale());
+        assertEquals(newStock, testOptionDetail.getStock());
+    }
+}

--- a/src/test/java/com/liberty52/product/service/utils/MockFactory.java
+++ b/src/test/java/com/liberty52/product/service/utils/MockFactory.java
@@ -29,7 +29,7 @@ public class MockFactory {
     }
 
     public static OptionDetail createOptionDetail(String name, Integer price) {
-        return OptionDetail.create(name, price, true);
+        return OptionDetail.create(name, price, true,100);
     }
 
     public static CustomProductOption createProductCartOption() {


### PR DESCRIPTION
## 스프린트 넘버  : 2
### 백로그 이름 : 판매 상품 옵션 선택지 재고 수정 기능 (관리자)


***
### 작업

**API**
```
PUT /admin/optionDetail/{optionDetailId}

>> REQUEST
headers:
LB-Role: role
<<

data(JSON)
{
  "name": String
  "price": Integer
  "onSale": Boolean
  "stock" : Integer
}

status
200 ok - 삭제 성공
400 BadRequest - 잘못된 요청 (유효하지 않은 optionDetailId로 요청한 경우 등)
401 Unauthorized - 인증 실패 (로그인을 하지 않은 경우 등)
403 Forbidden - 인가 실패 (관리자가 아닌 계정으로 요청한 경우 등)
<<
```

***
### 테스트 결과
<img width="768" alt="스크린샷 2023-09-27 오후 2 21 08" src="https://github.com/Liberty52/product/assets/96376539/cba1d83b-e41e-40f1-ae3a-9f61353f01f3">


***
### 이슈
1. 재고량만 따로 수정하는 api가 아닌 기존 상품 옵션 선택지 수정 api에 재고량 항목을 추가하는 방식으로 구현했습니다.
2. 상품 옵션 선택지 필드를 OptionDetail 엔티티에 추가해서 기존에 존재하던 관련된 CRUD 코드들을 모두 일부 수정했습니다.(관련된 API 문서는 모두 이에 맞춰 수정했어요)
3. buider 패턴 사용할 수 있는 상황이면 가급적 .create 말고 builder 패턴으로 객체 생성하면 좋을것 같습니다! 유연성을 높여 요청 데이터를 추가할 때  테스트 코드부터 실제 서비스 코드까지 많은  부분을 수정해야하는 상황을 줄일 수 있을것 같습니다.