### PR TITLE
feat:관리자는 이미지를 업스케일(upscaling)한다.

### DIFF
--- a/src/main/java/com/liberty52/product/global/adapter/ImageUpscaler.java
+++ b/src/main/java/com/liberty52/product/global/adapter/ImageUpscaler.java
@@ -8,30 +8,30 @@ public interface ImageUpscaler {
 
     sealed class Scale {
         @Getter
-        static final class Mul extends Scale {
+        public static final class Mul extends Scale {
             private final Double width;
             private final Double height;
 
-            Mul(Double width) {
+            public Mul(Double width) {
                 this.width = this.height = width;
             }
 
-            Mul(Double width, Double height) {
+            public Mul(Double width, Double height) {
                 this.width = width;
                 this.height = height;
             }
         }
 
         @Getter
-        static final class Fix extends Scale {
+        public static final class Fix extends Scale {
             private final Long width;
             private final Long height;
 
-            Fix(Long length) {
+            public Fix(Long length) {
                 this.width = this.height = length;
             }
 
-            Fix(Long width, Long height) {
+            public Fix(Long width, Long height) {
                 this.width = width;
                 this.height = height;
             }

--- a/src/main/java/com/liberty52/product/global/adapter/ImageUpscaler.java
+++ b/src/main/java/com/liberty52/product/global/adapter/ImageUpscaler.java
@@ -1,0 +1,40 @@
+package com.liberty52.product.global.adapter;
+
+import com.liberty52.product.global.util.Result;
+import lombok.Getter;
+
+public interface ImageUpscaler {
+    Result<String> upscale(String srcUri, Scale scale);
+
+    sealed class Scale {
+        @Getter
+        static final class Mul extends Scale {
+            private final Double width;
+            private final Double height;
+
+            Mul(Double width) {
+                this.width = this.height = width;
+            }
+
+            Mul(Double width, Double height) {
+                this.width = width;
+                this.height = height;
+            }
+        }
+
+        @Getter
+        static final class Fix extends Scale {
+            private final Long width;
+            private final Long height;
+
+            Fix(Long length) {
+                this.width = this.height = length;
+            }
+
+            Fix(Long width, Long height) {
+                this.width = width;
+                this.height = height;
+            }
+        }
+    }
+}

--- a/src/main/java/com/liberty52/product/global/adapter/StableDiffusionApi.java
+++ b/src/main/java/com/liberty52/product/global/adapter/StableDiffusionApi.java
@@ -1,0 +1,79 @@
+package com.liberty52.product.global.adapter;
+
+import com.liberty52.product.global.util.Result;
+import jakarta.annotation.PostConstruct;
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Objects;
+
+@Component
+@Slf4j
+public class StableDiffusionApi implements ImageUpscaler {
+    @Value("${stable-diffusion.key}")
+    private String API_KEY;
+
+    @Value("${stable-diffusion.url.base}")
+    private String BASE_URL;
+
+    @Value("${stable-diffusion.url.super-resolution}")
+    private String SUPER_RESOLUTION;
+
+    private WebClient webClient;
+
+    @PostConstruct
+    private void init() {
+        webClient = WebClient.builder()
+            .baseUrl(BASE_URL)
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .build();
+    }
+
+
+    @Override
+    public Result<String> upscale(String srcUri, Scale scale) {
+        System.out.println(BASE_URL);
+        return Result.runCatching(
+                () -> webClient.post()
+                    .uri(SUPER_RESOLUTION)
+                    .body(BodyInserters.fromValue(
+                        Dto.Request.builder()
+                            .key(API_KEY)
+                            .url(srcUri)
+                            .scale(((Scale.Mul) scale).getWidth().intValue())
+                            .build())
+                    ).retrieve()
+                    .bodyToMono(Dto.Response.class)
+                    .block()
+            ).onSuccess(body -> log.info("{}/upscaling success. body={}.", this.getClass().getSimpleName(), body.toString()))
+            .mapCatching(body -> Objects.requireNonNull(body).output)
+            .onFailure(err -> log.error("{}/upscaling. Error: {}.", this.getClass().getSimpleName(), err.getMessage()));
+    }
+
+    public static class Dto {
+        @Builder
+        public record Request(
+            String key,
+            String url,
+            Integer scale,
+            String model_id,
+            String webhook,
+            Boolean face_enhancer
+        ) {
+        }
+
+        public record Response(
+            String status,
+            Double generationTime,
+            Long id,
+            String output
+        ) {
+        }
+    }
+}

--- a/src/main/java/com/liberty52/product/global/util/Result.java
+++ b/src/main/java/com/liberty52/product/global/util/Result.java
@@ -1,0 +1,223 @@
+package com.liberty52.product.global.util;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public abstract sealed class Result<T> {
+    public abstract T getOrThrow() throws Throwable;
+
+    public abstract Result<T> onSuccess(Consumer<T> consumer);
+
+    public abstract Result<T> onFailure(Consumer<Throwable> consumer);
+
+    public abstract T getOrElse(Function<Throwable, T> func);
+
+    public abstract T getOrDefault(T defaultValue);
+
+    public abstract Boolean isSuccess();
+
+    public abstract Boolean isFailure();
+
+    public abstract T getOrNull();
+
+    public abstract Throwable exceptionOrNull();
+
+    public abstract <K> Result<K> map(Function<T, K> transform);
+
+    public abstract <K> Result<K> mapCatching(Function<T, K> transform);
+
+    public abstract Result<T> recover(Function<Throwable, T> transform);
+
+    public abstract Result<T> recoverCatching(Function<Throwable, T> transform);
+
+    public static <T> Result<T> success(T value) {
+        return new Success<>(value);
+    }
+
+    public static <T> Result<T> failure(Throwable throwable) {
+        return new Failure<>(throwable);
+    }
+
+    public static <T> Result<T> runCatching(Supplier<T> supplier) {
+        try {
+            return success(supplier.get());
+        } catch (Throwable t) {
+            return failure(t);
+        }
+    }
+
+    public static final class Success<T> extends Result<T> {
+        private final T value;
+
+        public Success(T value) {
+            this.value = value;
+        }
+
+        @Override
+        public T getOrThrow() {
+            return value;
+        }
+
+        @Override
+        public Result<T> onSuccess(Consumer<T> consumer) {
+            consumer.accept(value);
+            return this;
+        }
+
+        @Override
+        public Result<T> onFailure(Consumer<Throwable> consumer) {
+            return this;
+        }
+
+        @Override
+        public T getOrElse(Function<Throwable, T> func) {
+            return value;
+        }
+
+        @Override
+        public T getOrDefault(T defaultValue) {
+            return value;
+        }
+
+        @Override
+        public Boolean isSuccess() {
+            return true;
+        }
+
+        @Override
+        public Boolean isFailure() {
+            return false;
+        }
+
+        @Override
+        public T getOrNull() {
+            return value;
+        }
+
+        @Override
+        public Throwable exceptionOrNull() {
+            return null;
+        }
+
+        @Override
+        public <K> Result<K> map(Function<T, K> transform) {
+            return success(transform.apply(value));
+        }
+
+        @Override
+        public <K> Result<K> mapCatching(Function<T, K> transform) {
+            try {
+                return map(transform);
+            } catch (Throwable throwable) {
+                return failure(throwable);
+            }
+        }
+
+        @Override
+        public Result<T> recover(Function<Throwable, T> transform) {
+            return this;
+        }
+
+        @Override
+        public Result<T> recoverCatching(Function<Throwable, T> transform) {
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return "Success{" +
+                "value=" + value +
+                '}';
+        }
+    }
+
+    public static final class Failure<T> extends Result<T> {
+        private final Throwable error;
+
+        public Failure(Throwable throwable) {
+            this.error = throwable;
+        }
+
+        @Override
+        public T getOrThrow() throws Throwable {
+            throw error;
+        }
+
+        @Override
+        public Result<T> onSuccess(Consumer<T> consumer) {
+            return this;
+        }
+
+        @Override
+        public Result<T> onFailure(Consumer<Throwable> consumer) {
+            consumer.accept(error);
+            return this;
+        }
+
+        @Override
+        public T getOrElse(Function<Throwable, T> func) {
+            return func.apply(error);
+        }
+
+        @Override
+        public T getOrDefault(T defaultValue) {
+            return defaultValue;
+        }
+
+        @Override
+        public Boolean isSuccess() {
+            return false;
+        }
+
+        @Override
+        public Boolean isFailure() {
+            return true;
+        }
+
+        @Override
+        public T getOrNull() {
+            return null;
+        }
+
+        @Override
+        public Throwable exceptionOrNull() {
+            return error;
+        }
+
+        @Override
+        public <K> Result<K> map(Function<T, K> transform) {
+            return failure(error);
+        }
+
+        @Override
+        public <K> Result<K> mapCatching(Function<T, K> transform) {
+            try {
+                return map(transform);
+            } catch (Throwable t) {
+                return failure(t);
+            }
+        }
+
+        @Override
+        public Result<T> recover(Function<Throwable, T> transform) {
+            return success(transform.apply(error));
+        }
+
+        @Override
+        public Result<T> recoverCatching(Function<Throwable, T> transform) {
+            try {
+                return recover(transform);
+            } catch (Throwable t) {
+                return failure(t);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "Failure{" +
+                "error=" + error +
+                '}';
+        }
+    }
+}

--- a/src/main/java/com/liberty52/product/global/util/Result.java
+++ b/src/main/java/com/liberty52/product/global/util/Result.java
@@ -47,6 +47,10 @@ public abstract sealed class Result<T> {
         }
     }
 
+    public abstract T getOrElseThrow(Function<Throwable, RuntimeException> func) throws RuntimeException;
+
+    public abstract T getOrElseThrow(Supplier<RuntimeException> supplier) throws RuntimeException;
+
     public static final class Success<T> extends Result<T> {
         private final T value;
 
@@ -122,6 +126,16 @@ public abstract sealed class Result<T> {
         @Override
         public Result<T> recoverCatching(Function<Throwable, T> transform) {
             return this;
+        }
+
+        @Override
+        public T getOrElseThrow(Function<Throwable, RuntimeException> func) throws RuntimeException {
+            return value;
+        }
+
+        @Override
+        public T getOrElseThrow(Supplier<RuntimeException> supplier) throws RuntimeException {
+            return value;
         }
 
         @Override
@@ -211,6 +225,16 @@ public abstract sealed class Result<T> {
             } catch (Throwable t) {
                 return failure(t);
             }
+        }
+
+        @Override
+        public T getOrElseThrow(Function<Throwable, RuntimeException> func) throws RuntimeException {
+            throw func.apply(error);
+        }
+
+        @Override
+        public T getOrElseThrow(Supplier<RuntimeException> supplier) throws RuntimeException {
+            throw supplier.get();
         }
 
         @Override

--- a/src/main/java/com/liberty52/product/service/applicationservice/ImageUpscalingService.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/ImageUpscalingService.java
@@ -1,0 +1,7 @@
+package com.liberty52.product.service.applicationservice;
+
+import com.liberty52.product.service.controller.dto.ImageUpscalingDto;
+
+public interface ImageUpscalingService {
+    ImageUpscalingDto.Response upscale(String url, Integer scale);
+}

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/ImageUpscalingServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/ImageUpscalingServiceImpl.java
@@ -1,0 +1,25 @@
+package com.liberty52.product.service.applicationservice.impl;
+
+import com.liberty52.product.global.adapter.ImageUpscaler;
+import com.liberty52.product.global.exception.external.internalservererror.InternalServerErrorException;
+import com.liberty52.product.service.applicationservice.ImageUpscalingService;
+import com.liberty52.product.service.controller.dto.ImageUpscalingDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ImageUpscalingServiceImpl implements ImageUpscalingService {
+    private final ImageUpscaler imageUpscaler;
+
+    @Override
+    public ImageUpscalingDto.Response upscale(String url, Integer scale) {
+        String afterUrl = imageUpscaler.upscale(
+            url,
+            new ImageUpscaler.Scale.Mul(scale.doubleValue())
+        ).getOrElseThrow(() -> new InternalServerErrorException("다음의 가능성이 있습니다. 잘못된 url, scale. API rate limit 초과. API key 만료."));
+        return new ImageUpscalingDto.Response(url, afterUrl);
+    }
+}

--- a/src/main/java/com/liberty52/product/service/controller/ImageUpscalingController.java
+++ b/src/main/java/com/liberty52/product/service/controller/ImageUpscalingController.java
@@ -1,0 +1,25 @@
+package com.liberty52.product.service.controller;
+
+import com.liberty52.product.service.applicationservice.ImageUpscalingService;
+import com.liberty52.product.service.controller.dto.ImageUpscalingDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ImageUpscalingController {
+    private final ImageUpscalingService service;
+
+    @PostMapping("/images/upscaling")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ImageUpscalingDto.Response generateImage(
+        @Validated @RequestBody ImageUpscalingDto.Request requestBody
+    ) {
+        return service.upscale(requestBody.url(), requestBody.scale());
+    }
+}

--- a/src/main/java/com/liberty52/product/service/controller/dto/ImageUpscalingDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/ImageUpscalingDto.java
@@ -1,0 +1,15 @@
+package com.liberty52.product.service.controller.dto;
+
+public class ImageUpscalingDto {
+    public record Request(
+        String url,
+        Integer scale
+    ) {
+    }
+
+    public record Response(
+        String beforeUrl,
+        String afterUrl
+    ) {
+    }
+}

--- a/src/test/java/com/liberty52/product/global/adapter/StableDiffusionApiTest.java
+++ b/src/test/java/com/liberty52/product/global/adapter/StableDiffusionApiTest.java
@@ -1,6 +1,5 @@
-package com.liberty52.product.global.adapter.imageupscaler;
+package com.liberty52.product.global.adapter;
 
-import com.liberty52.product.global.adapter.ImageUpscaler;
 import com.liberty52.product.global.util.Result;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/liberty52/product/global/adapter/imageupscaler/StableDiffusionApiTest.java
+++ b/src/test/java/com/liberty52/product/global/adapter/imageupscaler/StableDiffusionApiTest.java
@@ -1,0 +1,28 @@
+package com.liberty52.product.global.adapter.imageupscaler;
+
+import com.liberty52.product.global.adapter.ImageUpscaler;
+import com.liberty52.product.global.util.Result;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@Disabled // 비용이 발생하는 테스트입니다. 이 어노테이션을 지우지 말아주세요.
+class StableDiffusionApiTest {
+    @Autowired
+    private ImageUpscaler imageUpscaler;
+
+    @Test
+    void success() {
+        Result<String> result = imageUpscaler.upscale(
+            "https://liberty52.s3.ap-northeast-2.amazonaws.com/product/custom/0009388f-09b4-459b-82b1-49bd5ad6de64.jpg",
+            new ImageUpscaler.Scale.Mul(2.0)
+        );
+        assertTrue(result.isSuccess());
+        assertNotNull(result.getOrNull());
+    }
+}

--- a/src/test/java/com/liberty52/product/service/applicationservice/impl/ImageUpscalingServiceImplTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/impl/ImageUpscalingServiceImplTest.java
@@ -1,0 +1,38 @@
+package com.liberty52.product.service.applicationservice.impl;
+
+import com.liberty52.product.global.adapter.ImageUpscaler;
+import com.liberty52.product.global.adapter.StableDiffusionApi;
+import com.liberty52.product.global.exception.external.internalservererror.InternalServerErrorException;
+import com.liberty52.product.global.util.Result;
+import com.liberty52.product.service.controller.dto.ImageUpscalingDto;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class ImageUpscalingServiceImplTest {
+    private final ImageUpscaler imageUpscaler = mock(StableDiffusionApi.class);
+
+    private final ImageUpscalingServiceImpl service = new ImageUpscalingServiceImpl(imageUpscaler);
+
+    @Test
+    void success() {
+        String exp = UUID.randomUUID().toString();
+        given(imageUpscaler.upscale(any(), any()))
+            .willReturn(Result.success(exp));
+        ImageUpscalingDto.Response act = service.upscale(UUID.randomUUID().toString(), 2);
+        assertEquals(exp, act.afterUrl());
+    }
+
+    @Test
+    void failure() {
+        given(imageUpscaler.upscale(any(), any()))
+            .willReturn(Result.failure(new RuntimeException()));
+        assertThrows(InternalServerErrorException.class, () -> service.upscale(UUID.randomUUID().toString(), 2));
+    }
+}

--- a/src/test/java/com/liberty52/product/service/controller/ImageUpscalingControllerTest.java
+++ b/src/test/java/com/liberty52/product/service/controller/ImageUpscalingControllerTest.java
@@ -1,0 +1,45 @@
+package com.liberty52.product.service.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.liberty52.product.service.applicationservice.ImageUpscalingService;
+import com.liberty52.product.service.controller.dto.ImageUpscalingDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ImageUpscalingController.class)
+class ImageUpscalingControllerTest {
+    @MockBean
+    private ImageUpscalingService service;
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    void success() throws Exception {
+        ImageUpscalingDto.Response exp = new ImageUpscalingDto.Response(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        given(service.upscale(any(), anyInt()))
+            .willReturn(exp);
+
+        mvc.perform(
+                post("/images/upscaling")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(new ObjectMapper().writeValueAsString(new ImageUpscalingDto.Request(exp.beforeUrl(), 2)))
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(status().isCreated())
+            .andExpect(jsonPath("$.beforeUrl").value(exp.beforeUrl()))
+            .andExpect(jsonPath("$.afterUrl").value(exp.afterUrl()));
+    }
+}


### PR DESCRIPTION
## 스프린트 넘버  : 2
## 메이저 마일스톤 : 이미지 업스케일
### 백로그 이름 : 이미지 scale-up AI

- [x] ImageUpscaler 구현
- [x] 관리자용 API 구현

[Base requirement](https://github.com/Liberty52/config-file-repository/issues)
[Stable-Diffusion upscaler API](https://stablediffusionapi.com/docs/image-editing/super-resolution)

***
### 작업
나중에 `ImageUpscaler` 구현체가 바뀔 수도 있을 거 같아서 인터페이스로 뺐습니다.

**API**
#256 


***
### 테스트 결과
API 동작 확인
- before 1920x1263
![전경](https://github.com/Liberty52/product/assets/74762475/089117fd-fd84-4437-868a-69bdb7490618)

- after 3840x2526
![after](https://pub-3626123a908346a7a8be8d9295f44e26.r2.dev/generations/beaf9680-2bb8-4f40-a226-6b3b51f77b19_out.png)
https://pub-3626123a908346a7a8be8d9295f44e26.r2.dev/generations/beaf9680-2bb8-4f40-a226-6b3b51f77b19_out.png
사진이 너무 큰지 안 뜨네요

***
### 이슈
