### PR TITLE
fix: ObjectMapper 기본생성자 요구 모듈 추가

### DIFF
--- a/src/main/java/com/liberty52/product/global/config/BeanConfig.java
+++ b/src/main/java/com/liberty52/product/global/config/BeanConfig.java
@@ -17,6 +17,7 @@ public class BeanConfig {
      * PortOne API를 호출하는 WebClient.
      */
     @Bean
+    @SuppressWarnings("deprecation")
     public WebClient webClient() {
         HttpClient httpClient = HttpClient.create()
                 .tcpConfiguration(

--- a/src/main/java/com/liberty52/product/global/config/JacksonConfig.java
+++ b/src/main/java/com/liberty52/product/global/config/JacksonConfig.java
@@ -1,0 +1,26 @@
+package com.liberty52.product.global.config;
+
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class JacksonConfig {
+
+	@Bean
+    @Primary
+	public ObjectMapper objectMapper() {
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.registerModules(
+                new JavaTimeModule(),
+                new ParameterNamesModule() // ParameterNamesModule은 기본 생성자가 없어도 Deserialize가 가능하도록 해주는 모듈
+        );
+		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+		return mapper;
+	}
+}

--- a/src/main/java/com/liberty52/product/service/entity/payment/VBankPayment.java
+++ b/src/main/java/com/liberty52/product/service/entity/payment/VBankPayment.java
@@ -36,6 +36,7 @@ public class VBankPayment extends Payment<VBankPayment.VBankPaymentInfo> {
     }
 
     @Override
+    @SuppressWarnings({"JpaAttributeTypeInspection", "unchecked"})
     public VBankPayment.VBankPaymentInfo getInfoAsDto() {
         try {
             return objectMapper.readValue(this.info, VBankPaymentInfo.class);


### PR DESCRIPTION
## 스프린트 넘버  : 
## 메이저 마일스톤 :
### 마이너 마일스톤 :
### 백로그 이름 :

Resolve #262 

***
### 작업

ObjectMapper에 기본 생성자가 없어도 역직렬화 가능하게 해주는 `ParameterNamesModule` 추가

**AS-IS**
```java
	@Bean
	public ObjectMapper objectMapper() {
		ObjectMapper mapper = new ObjectMapper();
		mapper.registerModule(new JavaTimeModule());
		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
		return mapper;
	}
```

**TO-BE**
```java
	@Bean
	public ObjectMapper objectMapper() {
		ObjectMapper mapper = new ObjectMapper();
		mapper.registerModules(
                          new JavaTimeModule(),
                          new ParameterNamesModule()
                );
		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
		return mapper;
	}
```