### PR TITLE
재고량 감소 비동기 데이터 정합성 보장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,10 @@ dependencies {
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
+    // redis & redisson
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson:3.17.1'
+
 	// Querydsl 추가
 	implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
 	implementation 'org.projectlombok:lombok:1.18.22'

--- a/src/main/java/com/liberty52/product/global/annotation/DistributedLock.java
+++ b/src/main/java/com/liberty52/product/global/annotation/DistributedLock.java
@@ -26,8 +26,8 @@ public @interface DistributedLock {
     long waitTime() default 5L;
 
     /**
-     * 락 임대 시간 (default - 3s) <br>
+     * 락 임대 시간 (default - 5s) <br>
      * 락을 획득한 이후 leaseTime 이 지나면 락을 해제한다
      */
-    long leaseTime() default 3L;
+    long leaseTime() default 5L;
 }

--- a/src/main/java/com/liberty52/product/global/annotation/DistributedLock.java
+++ b/src/main/java/com/liberty52/product/global/annotation/DistributedLock.java
@@ -1,0 +1,33 @@
+package com.liberty52.product.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+    /**
+     * 락의 이름
+     */
+    String key();
+
+    /**
+     * 락의 시간 단위
+     */
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    /**
+     * 락을 기다리는 시간 (default - 5s) <br>
+     * 락 획득을 위해 waitTime 만큼 대기한다
+     */
+    long waitTime() default 5L;
+
+    /**
+     * 락 임대 시간 (default - 3s) <br>
+     * 락을 획득한 이후 leaseTime 이 지나면 락을 해제한다
+     */
+    long leaseTime() default 3L;
+}

--- a/src/main/java/com/liberty52/product/global/aspect/DistributedLockAspect.java
+++ b/src/main/java/com/liberty52/product/global/aspect/DistributedLockAspect.java
@@ -55,7 +55,7 @@ public class DistributedLockAspect {
             try {
                 lock.unlock();
                 long end = System.currentTimeMillis();
-                log.info("[Distributed Lock] Distributed Lock - {} release lock. Lock using on {}ms", key, end - start);
+                log.info("[Distributed Lock] - {} release lock. Lock using on {}ms", key, end - start);
             } catch (IllegalMonitorStateException e) {
                 log.info("[Distributed Lock] - Already UnLock. serviceName -> {}, key -> {}", method.getName(), key);
             }

--- a/src/main/java/com/liberty52/product/global/aspect/DistributedLockAspect.java
+++ b/src/main/java/com/liberty52/product/global/aspect/DistributedLockAspect.java
@@ -1,0 +1,61 @@
+package com.liberty52.product.global.aspect;
+
+import com.liberty52.product.global.annotation.DistributedLock;
+import com.liberty52.product.global.util.CustomSpringELParser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class DistributedLockAspect {
+
+    private static final String REDISSON_LOCK_PREFIX = "LOCK:";
+
+    private final RedissonClient redissonClient;
+    private final DistributedLockTransaction transaction;
+
+    @Around("@annotation(com.liberty52.product.global.annotation.DistributedLock)")
+    public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        DistributedLock dLock = method.getAnnotation(DistributedLock.class);
+
+        String key = REDISSON_LOCK_PREFIX +
+                CustomSpringELParser.getDynamicValue(
+                        signature.getParameterNames(),
+                        joinPoint.getArgs(),
+                        dLock.key());
+
+        RLock lock = redissonClient.getLock(key);
+
+        try {
+            boolean available = lock.tryLock(dLock.waitTime(), dLock.leaseTime(), dLock.timeUnit());
+            log.debug("[LB-LOG] Distributed Lock - {} get lock", key);
+            if (!available) {
+                return false;
+            }
+            return transaction.proceed(joinPoint);
+        } catch (InterruptedException e) {
+            log.error("Occurred InterruptedException during Redisson Lock\n", e);
+            throw e;
+        } finally {
+            try {
+                lock.unlock();
+                log.debug("[LB-LOG] Distributed Lock - {} release lock", key);
+            } catch (IllegalMonitorStateException e) {
+                log.info("Redisson Lock Already UnLock. serviceName -> {}, key -> {}", method.getName(), key);
+            }
+        }
+    }
+}

--- a/src/main/java/com/liberty52/product/global/aspect/DistributedLockTransaction.java
+++ b/src/main/java/com/liberty52/product/global/aspect/DistributedLockTransaction.java
@@ -1,0 +1,16 @@
+package com.liberty52.product.global.aspect;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class DistributedLockTransaction {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+
+}

--- a/src/main/java/com/liberty52/product/global/aspect/DistributedLockTransaction.java
+++ b/src/main/java/com/liberty52/product/global/aspect/DistributedLockTransaction.java
@@ -8,6 +8,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 public class DistributedLockTransaction {
 
+    /**
+     * 더티 커밋 같은 문제가 없도록 데이터 정합성을 보장하기 위해 <br>
+     * 분산락에 해당하는 로직을 서로 다른 트랜잭션으로 실행한다.
+     */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
         return joinPoint.proceed();

--- a/src/main/java/com/liberty52/product/global/config/AspectConfig.java
+++ b/src/main/java/com/liberty52/product/global/config/AspectConfig.java
@@ -1,0 +1,9 @@
+package com.liberty52.product.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+@Configuration
+@EnableAspectJAutoProxy
+public class AspectConfig {
+}

--- a/src/main/java/com/liberty52/product/global/config/RedisConfig.java
+++ b/src/main/java/com/liberty52/product/global/config/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.liberty52.product.global.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer().setAddress("redis://" + host + ":" + port);
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/com/liberty52/product/global/event/events/OrderFailedPayRollbackEvent.java
+++ b/src/main/java/com/liberty52/product/global/event/events/OrderFailedPayRollbackEvent.java
@@ -1,0 +1,6 @@
+package com.liberty52.product.global.event.events;
+
+import com.liberty52.product.service.event.Event;
+
+public record OrderFailedPayRollbackEvent(String orderId) implements Event {
+}

--- a/src/main/java/com/liberty52/product/global/event/handler/OrderFailedPayRollbackEventHandler.java
+++ b/src/main/java/com/liberty52/product/global/event/handler/OrderFailedPayRollbackEventHandler.java
@@ -1,0 +1,25 @@
+package com.liberty52.product.global.event.handler;
+
+import com.liberty52.product.global.event.events.OrderFailedPayRollbackEvent;
+import com.liberty52.product.service.applicationservice.OrderFailedPayRollbackService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderFailedPayRollbackEventHandler {
+
+    private final OrderFailedPayRollbackService service;
+
+    @Async
+    @EventListener(OrderFailedPayRollbackEvent.class)
+    public void handleOrderFailedPayRollbackEvent(OrderFailedPayRollbackEvent event) {
+        String orderId = event.orderId();
+        service.rollback(orderId);
+        log.info("Success rollback failed order and option's stock. orderId={}", orderId);
+    }
+}

--- a/src/main/java/com/liberty52/product/global/exception/external/badrequest/DistributedLockException.java
+++ b/src/main/java/com/liberty52/product/global/exception/external/badrequest/DistributedLockException.java
@@ -1,0 +1,7 @@
+package com.liberty52.product.global.exception.external.badrequest;
+
+public class DistributedLockException extends BadRequestException {
+    public DistributedLockException() {
+        super("현재 동시 요청자가 많습니다. 다시 요청해주세요.");
+    }
+}

--- a/src/main/java/com/liberty52/product/global/util/CustomSpringELParser.java
+++ b/src/main/java/com/liberty52/product/global/util/CustomSpringELParser.java
@@ -1,0 +1,20 @@
+package com.liberty52.product.global.util;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class CustomSpringELParser {
+    private CustomSpringELParser() {}
+
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/src/main/java/com/liberty52/product/global/util/Result.java
+++ b/src/main/java/com/liberty52/product/global/util/Result.java
@@ -7,6 +7,8 @@ import java.util.function.Supplier;
 public abstract sealed class Result<T> {
     public abstract T getOrThrow() throws Throwable;
 
+    public abstract T getOrThrows() throws RuntimeException;
+
     public abstract Result<T> onSuccess(Consumer<T> consumer);
 
     public abstract Result<T> onFailure(Consumer<Throwable> consumer);
@@ -61,6 +63,11 @@ public abstract sealed class Result<T> {
         @Override
         public T getOrThrow() {
             return value;
+        }
+
+        @Override
+        public T getOrThrows() {
+             return value;
         }
 
         @Override
@@ -148,14 +155,21 @@ public abstract sealed class Result<T> {
 
     public static final class Failure<T> extends Result<T> {
         private final Throwable error;
+        private final RuntimeException runtimeException;
 
         public Failure(Throwable throwable) {
             this.error = throwable;
+            this.runtimeException = (RuntimeException) throwable;
         }
 
         @Override
         public T getOrThrow() throws Throwable {
             throw error;
+        }
+
+        @Override
+        public T getOrThrows() throws RuntimeException {
+            throw runtimeException;
         }
 
         @Override

--- a/src/main/java/com/liberty52/product/global/util/Result.java
+++ b/src/main/java/com/liberty52/product/global/util/Result.java
@@ -5,9 +5,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 public abstract sealed class Result<T> {
-    public abstract T getOrThrow() throws Throwable;
-
-    public abstract T getOrThrows() throws RuntimeException;
+    public abstract T getOrThrow() throws RuntimeException;
 
     public abstract Result<T> onSuccess(Consumer<T> consumer);
 
@@ -63,11 +61,6 @@ public abstract sealed class Result<T> {
         @Override
         public T getOrThrow() {
             return value;
-        }
-
-        @Override
-        public T getOrThrows() {
-             return value;
         }
 
         @Override
@@ -154,22 +147,19 @@ public abstract sealed class Result<T> {
     }
 
     public static final class Failure<T> extends Result<T> {
-        private final Throwable error;
-        private final RuntimeException runtimeException;
+        private final RuntimeException error;
 
         public Failure(Throwable throwable) {
-            this.error = throwable;
-            this.runtimeException = (RuntimeException) throwable;
+            if (throwable instanceof RuntimeException e) {
+                this.error = e;
+            } else {
+                this.error = new RuntimeException(throwable);
+            }
         }
 
         @Override
-        public T getOrThrow() throws Throwable {
+        public T getOrThrow() throws RuntimeException {
             throw error;
-        }
-
-        @Override
-        public T getOrThrows() throws RuntimeException {
-            throw runtimeException;
         }
 
         @Override

--- a/src/main/java/com/liberty52/product/service/applicationservice/OptionDetailMultipleStockManageService.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/OptionDetailMultipleStockManageService.java
@@ -1,0 +1,10 @@
+package com.liberty52.product.service.applicationservice;
+
+import com.liberty52.product.global.util.Result;
+import com.liberty52.product.service.entity.OptionDetail;
+
+import java.util.List;
+
+public interface OptionDetailMultipleStockManageService {
+    Result<List<OptionDetail>> decrement(List<String> optionDetailIds, int quantity);
+}

--- a/src/main/java/com/liberty52/product/service/applicationservice/OptionDetailStockManageService.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/OptionDetailStockManageService.java
@@ -3,12 +3,11 @@ package com.liberty52.product.service.applicationservice;
 import com.liberty52.product.global.util.Result;
 import com.liberty52.product.service.entity.OptionDetail;
 
-/**
- * 옵션 디테일의 재고량을 관리(증가, 감소)하기 위한 서버 내부용 서비스 인터페이스
- */
 public interface OptionDetailStockManageService {
 
     Result<OptionDetail> decrement(String optionDetailId, int quantity);
 
     Result<OptionDetail> increment(String optionDetailId, int quantity);
+
+    Result<OptionDetail> rollback(String optionDetailId, int quantity);
 }

--- a/src/main/java/com/liberty52/product/service/applicationservice/OptionDetailStockManageService.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/OptionDetailStockManageService.java
@@ -1,0 +1,14 @@
+package com.liberty52.product.service.applicationservice;
+
+import com.liberty52.product.global.util.Result;
+import com.liberty52.product.service.entity.OptionDetail;
+
+/**
+ * 옵션 디테일의 재고량을 관리(증가, 감소)하기 위한 서버 내부용 서비스 인터페이스
+ */
+public interface OptionDetailStockManageService {
+
+    Result<OptionDetail> decrement(String optionDetailId, int quantity);
+
+    Result<OptionDetail> increment(String optionDetailId, int quantity);
+}

--- a/src/main/java/com/liberty52/product/service/applicationservice/OrderFailedPayRollbackService.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/OrderFailedPayRollbackService.java
@@ -1,0 +1,5 @@
+package com.liberty52.product.service.applicationservice;
+
+public interface OrderFailedPayRollbackService {
+    void rollback(String orderId);
+}

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/OptionDetailMultipleStockManageServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/OptionDetailMultipleStockManageServiceImpl.java
@@ -1,0 +1,47 @@
+package com.liberty52.product.service.applicationservice.impl;
+
+import com.liberty52.product.global.util.Result;
+import com.liberty52.product.service.applicationservice.OptionDetailMultipleStockManageService;
+import com.liberty52.product.service.applicationservice.OptionDetailStockManageService;
+import com.liberty52.product.service.entity.OptionDetail;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OptionDetailMultipleStockManageServiceImpl implements OptionDetailMultipleStockManageService {
+
+    private final OptionDetailStockManageService stockManageService;
+
+    /**
+     * 해당 메소드는 DistributedLockTransaction을 통해 각각의 옵션 디테일 별로 트랜잭션이 생성됨에 따라
+     * 서로 다른 옵션 디테일 간의 트랜잭션을 코드 레벨에서 하나로 묶어서 예외 발생 시 롤백 시키기 위함이다. <br>
+     * 예를 들어, 옵션1, 옵션2, 옵션3에 대한 재고량을 감소시키던 도중에 옵션3의 재고량이 부족하여 예외가 발생하더라도
+     * 옵션1, 옵션2는 서로 다른 트랜잭션에 의해 update 커밋이 발생된 이후이기 때문에, 옵션1과 옵션2의 재고량이 감소되어 있다. <br>
+     * 따라서 예외 발생 시 재고량이 0이 아닌 옵션에 대해서만 롤백시키는 작업을 수행해야 한다.
+     */
+    @Override
+    @Transactional(propagation = Propagation.REQUIRED)
+    public Result<List<OptionDetail>> decrement(List<String> optionDetailIds, int quantity) {
+        return Result.runCatching(() -> {
+            List<OptionDetail> rollbackList = new ArrayList<>();
+            try {
+                return optionDetailIds.stream()
+                        .map(it -> {
+                            var optionDetail = stockManageService.decrement(it, quantity).getOrThrow();
+                            rollbackList.add(optionDetail);
+                            return optionDetail;
+                        })
+                        .toList();
+            } catch (Exception e) {
+                rollbackList.forEach(it -> stockManageService.rollback(it.getId(), quantity).getOrThrow());
+                throw e;
+            }
+        });
+    }
+}

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/OptionDetailStockManageServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/OptionDetailStockManageServiceImpl.java
@@ -10,6 +10,7 @@ import com.liberty52.product.service.repository.OptionDetailRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
@@ -20,7 +21,7 @@ public class OptionDetailStockManageServiceImpl implements OptionDetailStockMana
     private final OptionDetailRepository optionDetailRepository;
 
     @Override
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRED)
     @DistributedLock(key = "#optionDetailId")
     public Result<OptionDetail> decrement(String optionDetailId, int quantity) {
         return Result.runCatching(() -> {
@@ -32,12 +33,25 @@ public class OptionDetailStockManageServiceImpl implements OptionDetailStockMana
     }
 
     @Override
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRED)
     @DistributedLock(key = "#optionDetailId")
     public Result<OptionDetail> increment(String optionDetailId, int quantity) {
         return Result.runCatching(() -> {
             var optionDetail = this.findById(optionDetailId);
             optionDetail.rollbackStock(quantity);
+            return optionDetail;
+        });
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRED)
+    @DistributedLock(key = "#optionDetailId")
+    public Result<OptionDetail> rollback(String optionDetailId, int quantity) {
+        return Result.runCatching(() -> {
+            var optionDetail = this.findById(optionDetailId);
+            if (optionDetail.getStock() > 0) {
+                optionDetail.rollbackStock(quantity);
+            }
             return optionDetail;
         });
     }

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/OptionDetailStockManageServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/OptionDetailStockManageServiceImpl.java
@@ -1,0 +1,49 @@
+package com.liberty52.product.service.applicationservice.impl;
+
+import com.liberty52.product.global.annotation.DistributedLock;
+import com.liberty52.product.global.exception.external.badrequest.BadRequestException;
+import com.liberty52.product.global.exception.external.notfound.ResourceNotFoundException;
+import com.liberty52.product.global.util.Result;
+import com.liberty52.product.service.applicationservice.OptionDetailStockManageService;
+import com.liberty52.product.service.entity.OptionDetail;
+import com.liberty52.product.service.repository.OptionDetailRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OptionDetailStockManageServiceImpl implements OptionDetailStockManageService {
+
+    private final OptionDetailRepository optionDetailRepository;
+
+    @Override
+    @Transactional
+    @DistributedLock(key = "#optionDetailId")
+    public Result<OptionDetail> decrement(String optionDetailId, int quantity) {
+        return Result.runCatching(() -> {
+            var optionDetail = this.findById(optionDetailId);
+            optionDetail.sold(quantity)
+                    .orElseThrow(() -> new BadRequestException(optionDetail.getName() + " 옵션의 재고량이 부족하여 구매할 수 없습니다."));
+            return optionDetail;
+        });
+    }
+
+    @Override
+    @Transactional
+    @DistributedLock(key = "#optionDetailId")
+    public Result<OptionDetail> increment(String optionDetailId, int quantity) {
+        return Result.runCatching(() -> {
+            var optionDetail = this.findById(optionDetailId);
+            optionDetail.rollbackStock(quantity);
+            return optionDetail;
+        });
+    }
+
+    private OptionDetail findById(String id) {
+        return optionDetailRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("option detail", "id", id));
+    }
+}

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/OrderCreateServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/OrderCreateServiceImpl.java
@@ -1,6 +1,7 @@
 package com.liberty52.product.service.applicationservice.impl;
 
 import com.liberty52.product.global.adapter.s3.S3UploaderApi;
+import com.liberty52.product.global.annotation.DistributedLock;
 import com.liberty52.product.global.event.Events;
 import com.liberty52.product.global.event.events.CardOrderedCompletedEvent;
 import com.liberty52.product.global.event.events.OrderRequestDepositEvent;
@@ -86,6 +87,7 @@ public class OrderCreateServiceImpl implements OrderCreateService {
     }
 
     @Override
+    @DistributedLock(key = "#dto.getProductDto().getProductName()", waitTime = 7L)
     public PaymentCardResponseDto createCardPaymentOrders(String authId, OrderCreateRequestDto dto, MultipartFile imageFile) {
         Orders order = this.saveOrder(authId, dto, imageFile);
         this.saveCardPayment(order);
@@ -93,6 +95,7 @@ public class OrderCreateServiceImpl implements OrderCreateService {
     }
 
     @Override
+    @DistributedLock(key = "#dto.getProductDto().getProductName()", waitTime = 7L)
     public PaymentVBankResponseDto createVBankPaymentOrders(String authId, OrderCreateRequestDto dto, MultipartFile imageFile) {
         Orders order = this.saveOrder(authId, dto, imageFile);
         this.saveVBankPayment(dto, order);
@@ -100,6 +103,7 @@ public class OrderCreateServiceImpl implements OrderCreateService {
     }
 
     @Override
+    @DistributedLock(key = "#dto.getProductDto().getProductName()", waitTime = 7L)
     public PaymentCardResponseDto createCardPaymentOrdersByCarts(String authId, OrderCreateRequestDto dto) {
         List<CustomProduct> customProducts = this.getCustomProducts(authId, dto);
         Orders order = this.saveOrderByCarts(authId, dto, customProducts);
@@ -108,6 +112,7 @@ public class OrderCreateServiceImpl implements OrderCreateService {
     }
 
     @Override
+    @DistributedLock(key = "#dto.getProductDto().getProductName()", waitTime = 7L)
     public PaymentVBankResponseDto createVBankPaymentOrdersByCarts(String authId, OrderCreateRequestDto dto) {
         List<CustomProduct> customProducts = this.getCustomProducts(authId, dto);
         Orders order = this.saveOrderByCarts(authId, dto, customProducts);
@@ -116,6 +121,7 @@ public class OrderCreateServiceImpl implements OrderCreateService {
     }
 
     @Override
+    @DistributedLock(key = "#dto.getProductDto().getProductName()", waitTime = 7L)
     public PaymentCardResponseDto createCardPaymentOrdersByCartsForGuest(String authId, OrderCreateRequestDto dto) {
         List<CustomProduct> customProducts = this.getCustomProducts(authId, dto);
         Orders order = this.saveOrderByCarts(dto.getDestinationDto().getReceiverPhoneNumber(), dto, customProducts);
@@ -124,6 +130,7 @@ public class OrderCreateServiceImpl implements OrderCreateService {
     }
 
     @Override
+    @DistributedLock(key = "#dto.getProductDto().getProductName()", waitTime = 7L)
     public PaymentVBankResponseDto createVBankPaymentOrdersByCartsForGuest(String authId, OrderCreateRequestDto dto) {
         List<CustomProduct> customProducts = this.getCustomProducts(authId, dto);
         Orders order = this.saveOrderByCarts(dto.getDestinationDto().getReceiverPhoneNumber(), dto, customProducts);

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/OrderFailedPayRollbackServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/OrderFailedPayRollbackServiceImpl.java
@@ -1,0 +1,29 @@
+package com.liberty52.product.service.applicationservice.impl;
+
+import com.liberty52.product.service.applicationservice.OrderFailedPayRollbackService;
+import com.liberty52.product.service.entity.CustomProductOption;
+import com.liberty52.product.service.entity.Orders;
+import com.liberty52.product.service.repository.OrdersRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderFailedPayRollbackServiceImpl implements OrderFailedPayRollbackService {
+
+    private final OrdersRepository ordersRepository;
+
+    @Override
+    @Transactional
+    public void rollback(String orderId) {
+        Orders order = ordersRepository.findById(orderId)
+                .orElseThrow(RuntimeException::new);
+
+        order.getCustomProducts().forEach(cp -> {
+            cp.getOptions().stream()
+                    .map(CustomProductOption::getOptionDetail)
+                    .forEach(it -> it.rollbackStock(cp.getQuantity()));
+        });
+    }
+}

--- a/src/main/java/com/liberty52/product/service/entity/OptionDetail.java
+++ b/src/main/java/com/liberty52/product/service/entity/OptionDetail.java
@@ -71,4 +71,10 @@ public class OptionDetail {
             return Optional.of(this);
         }
     }
+
+    public void rollbackStock(int quantity) {
+        synchronized (this) {
+            this.stock += quantity;
+        }
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,10 +23,6 @@ spring:
   output:
     ansi:
       enabled: always
-  data:
-    redis:
-      host: localhost
-      port: 6379
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,10 @@ spring:
   output:
     ansi:
       enabled: always
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 logging:
   level:

--- a/src/test/java/com/liberty52/product/service/applicationservice/impl/OptionDetailStockManageServiceImplTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/impl/OptionDetailStockManageServiceImplTest.java
@@ -58,6 +58,36 @@ class OptionDetailStockManageServiceImplTest {
     }
 
     @Test
+    @DisplayName("재고량이 1개인 옵션의 재고량을 2개로 롤백시킨다")
+    void rollback_when_success() {
+        // given
+        final var optionDetail = initOptionDetail(1);
+        given(optionDetailRepository.findById(anyString()))
+                .willReturn(Optional.of(optionDetail));
+        // when
+        var result = service.rollback("id", 1).getOrNull();
+        // then
+        assertNotNull(result);
+        assertEquals(optionDetail, result);
+        assertEquals(2, result.getStock());
+    }
+
+    @Test
+    @DisplayName("재고량이 0개인 옵션의 재고량은 롤백되어 증가되지 않는다")
+    void rollback_when_success_zero_stock() {
+        // given
+        final var optionDetail = initOptionDetail(0);
+        given(optionDetailRepository.findById(anyString()))
+                .willReturn(Optional.of(optionDetail));
+        // when
+        var result = service.rollback("id", 1).getOrNull();
+        // then
+        assertNotNull(result);
+        assertEquals(optionDetail, result);
+        assertEquals(0, result.getStock());
+    }
+
+    @Test
     @DisplayName("존재하지 않는 옵션의 재고를 감소시킬 수 없다")
     void decrement_when_noResultOptionDetail() {
         // given
@@ -82,6 +112,20 @@ class OptionDetailStockManageServiceImplTest {
         assertThrows(
                 ResourceNotFoundException.class,
                 () -> service.increment("od", 2).getOrThrow()
+        );
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 옵션의 재고를 롤백할 수 없다")
+    void rollback_when_noResultOptionDetail() {
+        // given
+        given(optionDetailRepository.findById(anyString()))
+                .willReturn(Optional.empty());
+        // when
+        // then
+        assertThrows(
+                ResourceNotFoundException.class,
+                () -> service.rollback("od", 2).getOrThrow()
         );
     }
 

--- a/src/test/java/com/liberty52/product/service/applicationservice/impl/OptionDetailStockManageServiceImplTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/impl/OptionDetailStockManageServiceImplTest.java
@@ -1,0 +1,102 @@
+package com.liberty52.product.service.applicationservice.impl;
+
+import com.liberty52.product.global.exception.external.badrequest.BadRequestException;
+import com.liberty52.product.global.exception.external.notfound.ResourceNotFoundException;
+import com.liberty52.product.service.entity.OptionDetail;
+import com.liberty52.product.service.repository.OptionDetailRepository;
+import com.liberty52.product.service.utils.MockFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class OptionDetailStockManageServiceImplTest {
+
+    @InjectMocks private OptionDetailStockManageServiceImpl service;
+    @Mock private OptionDetailRepository optionDetailRepository;
+
+    private OptionDetail initOptionDetail(int stock) {
+        return MockFactory.createOptionDetail("od", 1000, stock);
+    }
+    @Test
+    @DisplayName("재고량이 100개인 옵션의 재고를 2개 감소시킨다")
+    void decrement_when_success() {
+        // given
+        final var optionDetail = initOptionDetail(100);
+        given(optionDetailRepository.findById(anyString()))
+                .willReturn(Optional.of(optionDetail));
+        // when
+        var result = service.decrement("id", 2).getOrNull();
+        // then
+        assertNotNull(result);
+        assertEquals(optionDetail, result);
+        assertEquals(98, result.getStock());
+    }
+
+    @Test
+    @DisplayName("재고량이 0개인 옵션의 재고를 2개 증가시킨다")
+    void increment_when_success() {
+        // given
+        final var optionDetail = initOptionDetail(0);
+        given(optionDetailRepository.findById(anyString()))
+                .willReturn(Optional.of(optionDetail));
+        // when
+        var result = service.increment("id", 2).getOrNull();
+        // then
+        assertNotNull(result);
+        assertEquals(optionDetail, result);
+        assertEquals(2, result.getStock());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 옵션의 재고를 감소시킬 수 없다")
+    void decrement_when_noResultOptionDetail() {
+        // given
+        given(optionDetailRepository.findById(anyString()))
+                .willReturn(Optional.empty());
+        // when
+        // then
+        assertThrows(
+                ResourceNotFoundException.class,
+                () -> service.decrement("od", 2).getOrThrow()
+        );
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 옵션의 재고를 증가시킬 수 없다")
+    void increment_when_noResultoptionDetail() {
+        // given
+        given(optionDetailRepository.findById(anyString()))
+                .willReturn(Optional.empty());
+        // when
+        // then
+        assertThrows(
+                ResourceNotFoundException.class,
+                () -> service.increment("od", 2).getOrThrow()
+        );
+    }
+
+    @Test
+    @DisplayName("재고량이 1개인 옵션의 재고를 2개 감소시킬 수 없다")
+    void decrement_when_noMoreStock() {
+        // given
+        final var od = initOptionDetail(1);
+        given(optionDetailRepository.findById(anyString()))
+                .willReturn(Optional.of(od));
+        // when
+        // then
+        assertThrows(
+                BadRequestException.class,
+                () -> service.decrement("od", 2).getOrThrow()
+        );
+    }
+}

--- a/src/test/java/com/liberty52/product/service/applicationservice/impl/OrderCreateServiceImplUnitTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/impl/OrderCreateServiceImplUnitTest.java
@@ -10,7 +10,7 @@ import com.liberty52.product.global.exception.external.internalservererror.Inter
 import com.liberty52.product.global.exception.external.notfound.ResourceNotFoundException;
 import com.liberty52.product.global.util.Result;
 import com.liberty52.product.global.util.ThreadManager;
-import com.liberty52.product.service.applicationservice.OptionDetailStockManageService;
+import com.liberty52.product.service.applicationservice.OptionDetailMultipleStockManageService;
 import com.liberty52.product.service.controller.dto.OrderCreateRequestDto;
 import com.liberty52.product.service.controller.dto.PaymentCardResponseDto;
 import com.liberty52.product.service.controller.dto.PaymentVBankResponseDto;
@@ -43,7 +43,7 @@ public class OrderCreateServiceImplUnitTest {
     @InjectMocks private OrderCreateServiceImpl service;
     @Mock private S3UploaderApi s3UploaderApi;
     @Mock private ProductRepository productRepository;
-    @Mock private OptionDetailStockManageService optionDetailStockManageService;
+    @Mock private OptionDetailMultipleStockManageService optionDetailMultipleStockManageService;
     @Mock private CustomProductRepository customProductRepository;
     @Mock private OrdersRepository ordersRepository;
     @Mock private OptionDetailRepository optionDetailRepository;
@@ -78,9 +78,9 @@ public class OrderCreateServiceImplUnitTest {
         optionDetails.forEach(it -> {
             given(optionDetailRepository.findByName(it.getName()))
                     .willReturn(Optional.of(it));
-            given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                    .willReturn(Result.success(it));
         });
+        given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                .willReturn(Result.success(optionDetails));
 
         var authId = "user_id";
         var order = MockFactory.createOrder(authId);
@@ -160,9 +160,9 @@ public class OrderCreateServiceImplUnitTest {
         optionDetails.forEach(it -> {
             lenient().when(optionDetailRepository.findByName(it.getName()))
                     .thenReturn(Optional.of(it));
-            given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                    .willReturn(Result.failure(new BadRequestException("")));
         });
+        given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                .willReturn(Result.failure(new BadRequestException("")));
         var options = optionDetails.stream().map(OptionDetail::getName).toList();
         // when
         // then
@@ -189,9 +189,9 @@ public class OrderCreateServiceImplUnitTest {
         optionDetails.forEach(it -> {
             lenient().when(optionDetailRepository.findByName(it.getName()))
                     .thenReturn(Optional.of(it));
-            given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                    .willReturn(Result.failure(new BadRequestException("")));
         });
+        given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                .willReturn(Result.failure(new BadRequestException("")));
         var options = optionDetails.stream().map(OptionDetail::getName).toList();
         // when
         // then
@@ -228,9 +228,9 @@ public class OrderCreateServiceImplUnitTest {
         optionDetails.forEach(it -> {
             given(optionDetailRepository.findByName(it.getName()))
                     .willReturn(Optional.of(it));
-            given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                    .willReturn(Result.success(it));
         });
+        given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                .willReturn(Result.success(optionDetails));
 
         var authId = "user_id";
         var order = MockFactory.createOrder(authId);
@@ -312,9 +312,9 @@ public class OrderCreateServiceImplUnitTest {
         optionDetails.forEach(it -> {
             lenient().when(optionDetailRepository.findByName(it.getName()))
                     .thenReturn(Optional.of(it));
-            given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                    .willReturn(Result.failure(new BadRequestException("")));
         });
+        given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                .willReturn(Result.failure(new BadRequestException("")));
 
         var options = optionDetails.stream().map(OptionDetail::getName).toList();
         // when
@@ -342,9 +342,9 @@ public class OrderCreateServiceImplUnitTest {
         optionDetails.forEach(it -> {
             lenient().when(optionDetailRepository.findByName(it.getName()))
                     .thenReturn(Optional.of(it));
-            given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                    .willReturn(Result.failure(new BadRequestException("")));
         });
+        given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                .willReturn(Result.failure(new BadRequestException("")));
         var options = optionDetails.stream().map(OptionDetail::getName).toList();
         // when
         // then
@@ -386,9 +386,9 @@ public class OrderCreateServiceImplUnitTest {
         customProducts.forEach(cp -> {
             optionDetails.forEach(od -> {
                 MockFactory.createCustomProductOption(cp, od);
-                given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                        .willReturn(Result.success(od));
             });
+            given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                    .willReturn(Result.success(optionDetails));
             given(customProductRepository.findById(cp.getId()))
                     .willReturn(Optional.of(cp));
         });
@@ -446,9 +446,9 @@ public class OrderCreateServiceImplUnitTest {
         customProducts.forEach(cp -> {
             optionDetails.forEach(od -> {
                 MockFactory.createCustomProductOption(cp, od);
-                given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                        .willReturn(Result.success(od));
             });
+            given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                    .willReturn(Result.success(optionDetails));
             given(customProductRepository.findById(cp.getId()))
                     .willReturn(Optional.of(cp));
         });
@@ -485,9 +485,9 @@ public class OrderCreateServiceImplUnitTest {
             optionDetails.forEach(od -> MockFactory.createCustomProductOption(cp, od));
             lenient().when(customProductRepository.findById(cp.getId()))
                     .thenReturn(Optional.of(cp));
-            given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                    .willReturn(Result.failure(new BadRequestException("")));
         });
+        given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                .willReturn(Result.failure(new BadRequestException("")));
         // when
         // then
         var cpIds = customProducts.stream().map(CustomProduct::getId).toList();
@@ -520,9 +520,9 @@ public class OrderCreateServiceImplUnitTest {
             optionDetails.forEach(od -> MockFactory.createCustomProductOption(cp, od));
             lenient().when(customProductRepository.findById(cp.getId()))
                     .thenReturn(Optional.of(cp));
-            given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                    .willReturn(Result.failure(new BadRequestException("")));
         });
+        given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                .willReturn(Result.failure(new BadRequestException("")));
         // when
         // then
         var cpIds = customProducts.stream().map(CustomProduct::getId).toList();
@@ -553,9 +553,9 @@ public class OrderCreateServiceImplUnitTest {
             optionDetails.forEach(od -> MockFactory.createCustomProductOption(cp, od));
             lenient().when(customProductRepository.findById(cp.getId()))
                     .thenReturn(Optional.of(cp));
-            given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                    .willReturn(Result.failure(new BadRequestException("")));
         });
+        given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                .willReturn(Result.failure(new BadRequestException("")));
         // when
         // then
         var cpIds = customProducts.stream().map(CustomProduct::getId).toList();
@@ -575,6 +575,7 @@ public class OrderCreateServiceImplUnitTest {
                 )
         );
     }
+
     @Test
     @DisplayName("장바구니에서 가상계좌 결제 주문을 요청하여 주문을 생성한다")
     void createVBankPaymentOrdersByCarts() {
@@ -597,9 +598,9 @@ public class OrderCreateServiceImplUnitTest {
         customProducts.forEach(cp -> {
             optionDetails.forEach(od -> {
                 MockFactory.createCustomProductOption(cp, od);
-                given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                        .willReturn(Result.success(od));
             });
+            given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                    .willReturn(Result.success(optionDetails));
             given(customProductRepository.findById(cp.getId()))
                     .willReturn(Optional.of(cp));
         });
@@ -658,9 +659,9 @@ public class OrderCreateServiceImplUnitTest {
         customProducts.forEach(cp -> {
             optionDetails.forEach(od -> {
                 MockFactory.createCustomProductOption(cp, od);
-                given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                        .willReturn(Result.success(od));
             });
+            given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                    .willReturn(Result.success(optionDetails));
             given(customProductRepository.findById(cp.getId()))
                     .willReturn(Optional.of(cp));
         });
@@ -697,9 +698,9 @@ public class OrderCreateServiceImplUnitTest {
             optionDetails.forEach(od -> MockFactory.createCustomProductOption(cp, od));
             lenient().when(customProductRepository.findById(cp.getId()))
                     .thenReturn(Optional.of(cp));
-            given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                    .willReturn(Result.failure(new BadRequestException("")));
         });
+        given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                .willReturn(Result.failure(new BadRequestException("")));
         // when
         // then
         var cpIds = customProducts.stream().map(CustomProduct::getId).toList();
@@ -732,9 +733,9 @@ public class OrderCreateServiceImplUnitTest {
             optionDetails.forEach(od -> MockFactory.createCustomProductOption(cp, od));
             lenient().when(customProductRepository.findById(cp.getId()))
                     .thenReturn(Optional.of(cp));
-            given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                    .willReturn(Result.failure(new BadRequestException("")));
         });
+        given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                .willReturn(Result.failure(new BadRequestException("")));
         // when
         // then
         var cpIds = customProducts.stream().map(CustomProduct::getId).toList();
@@ -765,9 +766,9 @@ public class OrderCreateServiceImplUnitTest {
             optionDetails.forEach(od -> MockFactory.createCustomProductOption(cp, od));
             lenient().when(customProductRepository.findById(cp.getId()))
                     .thenReturn(Optional.of(cp));
-            given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                    .willReturn(Result.failure(new BadRequestException("")));
         });
+        given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                .willReturn(Result.failure(new BadRequestException("")));
         // when
         // then
         var cpIds = customProducts.stream().map(CustomProduct::getId).toList();
@@ -809,9 +810,9 @@ public class OrderCreateServiceImplUnitTest {
         customProducts.forEach(cp -> {
             optionDetails.forEach(od -> {
                 MockFactory.createCustomProductOption(cp, od);
-                given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                        .willReturn(Result.success(od));
             });
+            given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                    .willReturn(Result.success(optionDetails));
             given(customProductRepository.findById(cp.getId()))
                     .willReturn(Optional.of(cp));
         });
@@ -868,9 +869,9 @@ public class OrderCreateServiceImplUnitTest {
         customProducts.forEach(cp -> {
             optionDetails.forEach(od -> {
                 MockFactory.createCustomProductOption(cp, od);
-                given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                        .willReturn(Result.success(od));
             });
+            given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                    .willReturn(Result.success(optionDetails));
             given(customProductRepository.findById(cp.getId()))
                     .willReturn(Optional.of(cp));
         });
@@ -907,9 +908,9 @@ public class OrderCreateServiceImplUnitTest {
             optionDetails.forEach(od -> MockFactory.createCustomProductOption(cp, od));
             lenient().when(customProductRepository.findById(cp.getId()))
                     .thenReturn(Optional.of(cp));
-            given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                    .willReturn(Result.failure(new BadRequestException("")));
         });
+        given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                .willReturn(Result.failure(new BadRequestException("")));
         // when
         // then
         var cpIds = customProducts.stream().map(CustomProduct::getId).toList();
@@ -942,9 +943,9 @@ public class OrderCreateServiceImplUnitTest {
             optionDetails.forEach(od -> MockFactory.createCustomProductOption(cp, od));
             lenient().when(customProductRepository.findById(cp.getId()))
                     .thenReturn(Optional.of(cp));
-            given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                    .willReturn(Result.failure(new BadRequestException("")));
         });
+        given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                .willReturn(Result.failure(new BadRequestException("")));
         // when
         // then
         var cpIds = customProducts.stream().map(CustomProduct::getId).toList();
@@ -975,9 +976,9 @@ public class OrderCreateServiceImplUnitTest {
             optionDetails.forEach(od -> MockFactory.createCustomProductOption(cp, od));
             lenient().when(customProductRepository.findById(cp.getId()))
                     .thenReturn(Optional.of(cp));
-            given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                    .willReturn(Result.failure(new BadRequestException("")));
         });
+        given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                .willReturn(Result.failure(new BadRequestException("")));
         // when
         // then
         var cpIds = customProducts.stream().map(CustomProduct::getId).toList();
@@ -1020,9 +1021,9 @@ public class OrderCreateServiceImplUnitTest {
         customProducts.forEach(cp -> {
             optionDetails.forEach(od -> {
                 MockFactory.createCustomProductOption(cp, od);
-                given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                        .willReturn(Result.success(od));
             });
+            given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                    .willReturn(Result.success(optionDetails));
             given(customProductRepository.findById(cp.getId()))
                     .willReturn(Optional.of(cp));
         });
@@ -1081,9 +1082,9 @@ public class OrderCreateServiceImplUnitTest {
         customProducts.forEach(cp -> {
             optionDetails.forEach(od -> {
                 MockFactory.createCustomProductOption(cp, od);
-                given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                        .willReturn(Result.success(od));
             });
+            given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                    .willReturn(Result.success(optionDetails));
             given(customProductRepository.findById(cp.getId()))
                     .willReturn(Optional.of(cp));
         });
@@ -1120,9 +1121,9 @@ public class OrderCreateServiceImplUnitTest {
             optionDetails.forEach(od -> MockFactory.createCustomProductOption(cp, od));
             lenient().when(customProductRepository.findById(cp.getId()))
                     .thenReturn(Optional.of(cp));
-            given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                    .willReturn(Result.failure(new BadRequestException("")));
         });
+        given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                .willReturn(Result.failure(new BadRequestException("")));
         // when
         // then
         var cpIds = customProducts.stream().map(CustomProduct::getId).toList();
@@ -1155,9 +1156,9 @@ public class OrderCreateServiceImplUnitTest {
             optionDetails.forEach(od -> MockFactory.createCustomProductOption(cp, od));
             lenient().when(customProductRepository.findById(cp.getId()))
                     .thenReturn(Optional.of(cp));
-            given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                    .willReturn(Result.failure(new BadRequestException("")));
         });
+        given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                .willReturn(Result.failure(new BadRequestException("")));
         // when
         // then
         var cpIds = customProducts.stream().map(CustomProduct::getId).toList();
@@ -1188,9 +1189,9 @@ public class OrderCreateServiceImplUnitTest {
             optionDetails.forEach(od -> MockFactory.createCustomProductOption(cp, od));
             lenient().when(customProductRepository.findById(cp.getId()))
                     .thenReturn(Optional.of(cp));
-            given(optionDetailStockManageService.decrement(anyString(), anyInt()))
-                    .willReturn(Result.failure(new BadRequestException("")));
         });
+        given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
+                .willReturn(Result.failure(new BadRequestException("")));
         // when
         // then
         var cpIds = customProducts.stream().map(CustomProduct::getId).toList();

--- a/src/test/java/com/liberty52/product/service/utils/MockFactory.java
+++ b/src/test/java/com/liberty52/product/service/utils/MockFactory.java
@@ -67,7 +67,7 @@ public class MockFactory {
     }
 
     public static OptionDetail createOptionDetail(String name, Integer price, Integer stock) {
-        return createOptionDetail(name, price, true, stock, null);
+        return createOptionDetail(name, price, true, stock, MockFactory.createProductOption("po", false));
     }
 
     public static OptionDetail createOptionDetail(String name, Integer price, Integer stock, ProductOption po) {


### PR DESCRIPTION
## 스프린트 넘버  : 3
## 메이저 마일스톤 : 상품
### 마이너 마일스톤 : 주문
### 백로그 이름 : 재고량 감소 비동기 데이터 정합성 보장

Resolve #269 

***
### 작업

1. 단건 주문, 장바구니 복수건 주문 등에서 발생하는 재고량 감소 시 데이터 접근에 대해 Redisson으로 락을 설정
2. 카드결제 주문 실패(위조 결제 등) 시 재고량을 롤백시키기 위한 이벤트 발행 및 컨슘 서비스 추가

각 옵션 디테일 별로 재고량을 확인하여 더티 커밋 등의 문제를 해결하기 위해  
옵션 디테일의 재고를 관리하기 위한 `OptionDetailStockManageService`를 생성하여  
해당 서비스 클래스 안에서 `@DistributedLock`을 이용하여 분산락을 구현하였습니다.

분산락과 관련된 기능들은 `global.annotation.DistributedLock`과 `global.aspect.DistributedLockAspect`에 구현하였습니다.

***
### 테스트 결과
<img width="400" alt="image" src="https://github.com/Liberty52/product/assets/42243302/97efdb2f-9f60-4d86-975b-1db177ee79fc">

<img width="500" alt="image" src="https://github.com/Liberty52/product/assets/42243302/f7348488-b031-4ff8-9272-a266074c146a">


***
### 이슈
@jinlee0 
> `Result<T>` 클래스와 관련하여 `runCatching()` 시 발생된 RuntimeException을 그대로  발생시키기 위해 `getOrThrows()` 인터페이스를 추가하였고, `Failure<T>` 클래스의 `runtimeException` 프로퍼티 추가 및 생성자에서 인자로 받은 `Throwable`을 RuntimeException으로 캐스팅하여 설정하도록 하였습니다.
임의로 추가해보았는데 컨펌 부탁드릴게요. :) 

@ImKunYoung 
> Redis의 설정을 모두 클라우드 환경의 레디스로 물리게끔 하고자 합니다. 로컬 프로파일에도 설정을 추가하면 모든 개발자들의 로컬에도 레디스가 운영되어 있어야 하는 문제가 예상되어서 이처럼 하고자 하는데, 의견 주시면 감사하겠습니다.