### PR TITLE
주문 요청 시 옵션명이 아닌 옵션 ID로 요청하도록 API 수정

### DIFF
--- a/src/main/java/com/liberty52/product/global/config/DBInitConfig.java
+++ b/src/main/java/com/liberty52/product/global/config/DBInitConfig.java
@@ -111,14 +111,23 @@ public class DBInitConfig {
 
                 OptionDetail materialOption2 = OptionDetail.create("무광실버", 100,true, 100);
                 materialOption2.associate(option3);
+                Field materialOption2Id = materialOption2.getClass().getDeclaredField("id");
+                materialOption2Id.setAccessible(true);
+                materialOption2Id.set(materialOption2, "OPT-005");
                 optionDetailRepository.save(materialOption2);
 
                 OptionDetail materialOption3 = OptionDetail.create("유광백색", 100,true, 100);
                 materialOption3.associate(option3);
+                Field materialOption3Id = materialOption3.getClass().getDeclaredField("id");
+                materialOption3Id.setAccessible(true);
+                materialOption3Id.set(materialOption3, "OPT-006");
                 optionDetailRepository.save(materialOption3);
 
                 OptionDetail materialOption4 = OptionDetail.create("무광백색", 100,true, 100);
                 materialOption4.associate(option3);
+                Field materialOption4Id = materialOption4.getClass().getDeclaredField("id");
+                materialOption4Id.setAccessible(true);
+                materialOption4Id.set(materialOption4, "OPT-007");
                 optionDetailRepository.save(materialOption4);
 
                 // Add Cart & CartItems

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/OrderCreateServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/OrderCreateServiceImpl.java
@@ -174,11 +174,10 @@ public class OrderCreateServiceImpl implements OrderCreateService {
     }
 
     private List<OptionDetail> getOptionDetails(OrderCreateRequestDto dto) {
-        List<String> optionDetailIds = dto.getProductDto().getOptions().stream()
-                //TODO option detail 조회를 id로 변경되면, 179 - 182를 합칠 수 있음.
-                .map(optionName -> optionDetailRepository.findByName(optionName)
-                        .orElseThrow(() -> new ResourceNotFoundException(RESOURCE_NAME_OPTION_DETAIL, PARAM_NAME_OPTION_DETAIL_NAME, optionName)))
-                .map(OptionDetail::getId)
+        List<String> optionDetailIds = dto.getProductDto().getOptionDetailIds().stream()
+                .map(it -> optionDetailRepository.findById(it)
+                        .orElseThrow(() -> new ResourceNotFoundException(RESOURCE_NAME_OPTION_DETAIL, PARAM_NAME_OPTION_DETAIL_NAME, it))
+                        .getId())
                 .toList();
         return optionDetailMultipleStockManageService.decrement(optionDetailIds, dto.getProductDto().getQuantity()).getOrThrow();
     }

--- a/src/main/java/com/liberty52/product/service/controller/dto/OrderCreateRequestDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/OrderCreateRequestDto.java
@@ -67,12 +67,12 @@ public class OrderCreateRequestDto {
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     public static class PaymentProductDto {
         private String productName;
-        private List<String> options;
+        private List<String> optionDetailIds;
         private int quantity;
         private List<String> orderOptions;
 
-        private static PaymentProductDto forTest(String pName, List<String> options, int quantity, List<String> orderOpts) {
-            return new PaymentProductDto(pName, options, quantity, orderOpts);
+        private static PaymentProductDto forTest(String pName, List<String> optionDetailIds, int quantity, List<String> orderOpts) {
+            return new PaymentProductDto(pName, optionDetailIds, quantity, orderOpts);
         }
 
     }

--- a/src/test/java/com/liberty52/product/service/applicationservice/OrderCreateServiceImplTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/OrderCreateServiceImplTest.java
@@ -53,9 +53,9 @@ class OrderCreateServiceImplTest extends MockS3Test {
     MockMultipartFile imageFile = new MockMultipartFile("image", "test.png", "image/jpeg", new FileInputStream("src/test/resources/static/test.jpg"));
 
     private static final String LIBERTY = "Liberty 52_Frame";
-    private static final String OPTION_1 = "이젤 거치형";
-    private static final String OPTION_2 = "1mm 두께 승화전사 인쇄용 알루미늄시트";
-    private static final String OPTION_3 = "유광실버";
+    private static final String OPTION_1 = "OPT-001";
+    private static final String OPTION_2 = "OPT-003";
+    private static final String OPTION_3 = "OPT-004";
     private static final int QUANTITY = 2;
 
     @Test

--- a/src/test/java/com/liberty52/product/service/applicationservice/impl/CanceledOrderRetrieveTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/impl/CanceledOrderRetrieveTest.java
@@ -85,9 +85,9 @@ public class CanceledOrderRetrieveTest extends MockAdaptersTest {
 
     MockMultipartFile imageFile = new MockMultipartFile("image", "test.png", "image/jpeg", new FileInputStream("src/test/resources/static/test.jpg"));
     private static final String LIBERTY = "Liberty 52_Frame";
-    private static final String OPTION_1 = "이젤 거치형";
-    private static final String OPTION_2 = "1mm 두께 승화전사 인쇄용 알루미늄시트";
-    private static final String OPTION_3 = "유광실버";
+    private static final String OPTION_1 = "OPT-001";
+    private static final String OPTION_2 = "OPT-003";
+    private static final String OPTION_3 = "OPT-004";
     private static final int QUANTITY = 2;
     void save_10_canceledOrders() {
         final String aid = UUID.randomUUID().toString();

--- a/src/test/java/com/liberty52/product/service/applicationservice/impl/OrderCreateServiceImplUnitTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/impl/OrderCreateServiceImplUnitTest.java
@@ -76,7 +76,7 @@ public class OrderCreateServiceImplUnitTest {
                 MockFactory.createOptionDetail("od_3", 30000, 10, productOption)
         );
         optionDetails.forEach(it -> {
-            given(optionDetailRepository.findByName(it.getName()))
+            given(optionDetailRepository.findById(it.getId()))
                     .willReturn(Optional.of(it));
         });
         given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
@@ -97,7 +97,7 @@ public class OrderCreateServiceImplUnitTest {
             given(customProductOptionRepository.save(any())).willReturn(cpo);
         });
 
-        var options = optionDetails.stream().map(OptionDetail::getName).toList();
+        var options = optionDetails.stream().map(OptionDetail::getId).toList();
         // when
         var result = executeCardPaymentOrders(authId, options, 1);
 
@@ -132,7 +132,7 @@ public class OrderCreateServiceImplUnitTest {
         var product = MockFactory.createProduct("pd");
         given(productRepository.findByName(anyString()))
                 .willReturn(Optional.of(product));
-        given(optionDetailRepository.findByName(anyString()))
+        given(optionDetailRepository.findById(anyString()))
                 .willReturn(Optional.empty());
         var options = List.of("not", "found", "optionDetail");
         // when
@@ -158,12 +158,12 @@ public class OrderCreateServiceImplUnitTest {
                 MockFactory.createOptionDetail("od_3", 30000, 0, productOption)
         );
         optionDetails.forEach(it -> {
-            lenient().when(optionDetailRepository.findByName(it.getName()))
+            lenient().when(optionDetailRepository.findById(it.getId()))
                     .thenReturn(Optional.of(it));
         });
         given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
                 .willReturn(Result.failure(new BadRequestException("")));
-        var options = optionDetails.stream().map(OptionDetail::getName).toList();
+        var options = optionDetails.stream().map(OptionDetail::getId).toList();
         // when
         // then
         assertThrows(
@@ -187,12 +187,12 @@ public class OrderCreateServiceImplUnitTest {
                 MockFactory.createOptionDetail("od_3", 30000, 1, productOption)
         );
         optionDetails.forEach(it -> {
-            lenient().when(optionDetailRepository.findByName(it.getName()))
+            lenient().when(optionDetailRepository.findById(it.getId()))
                     .thenReturn(Optional.of(it));
         });
         given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
                 .willReturn(Result.failure(new BadRequestException("")));
-        var options = optionDetails.stream().map(OptionDetail::getName).toList();
+        var options = optionDetails.stream().map(OptionDetail::getId).toList();
         // when
         // then
         assertThrows(
@@ -226,7 +226,7 @@ public class OrderCreateServiceImplUnitTest {
                 MockFactory.createOptionDetail("od_3", 30000, 10, productOption)
         );
         optionDetails.forEach(it -> {
-            given(optionDetailRepository.findByName(it.getName()))
+            given(optionDetailRepository.findById(it.getId()))
                     .willReturn(Optional.of(it));
         });
         given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
@@ -250,7 +250,7 @@ public class OrderCreateServiceImplUnitTest {
         given(vBankRepository.existsByBankAndAccountAndHolder(any(), anyString(), anyString()))
                 .willReturn(true);
 
-        var options = optionDetails.stream().map(OptionDetail::getName).toList();
+        var options = optionDetails.stream().map(OptionDetail::getId).toList();
 
         // when
         var result = executeVBankPaymentOrders(authId, options, 1);
@@ -284,7 +284,7 @@ public class OrderCreateServiceImplUnitTest {
         var product = MockFactory.createProduct("pd");
         given(productRepository.findByName(anyString()))
                 .willReturn(Optional.of(product));
-        given(optionDetailRepository.findByName(anyString()))
+        given(optionDetailRepository.findById(anyString()))
                 .willReturn(Optional.empty());
         // when
         // then
@@ -310,13 +310,13 @@ public class OrderCreateServiceImplUnitTest {
                 MockFactory.createOptionDetail("od_3", 30000, 0, productOption)
         );
         optionDetails.forEach(it -> {
-            lenient().when(optionDetailRepository.findByName(it.getName()))
+            lenient().when(optionDetailRepository.findById(it.getId()))
                     .thenReturn(Optional.of(it));
         });
         given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
                 .willReturn(Result.failure(new BadRequestException("")));
 
-        var options = optionDetails.stream().map(OptionDetail::getName).toList();
+        var options = optionDetails.stream().map(OptionDetail::getId).toList();
         // when
         // then
         assertThrows(
@@ -340,12 +340,12 @@ public class OrderCreateServiceImplUnitTest {
                 MockFactory.createOptionDetail("od_3", 30000, 1, productOption)
         );
         optionDetails.forEach(it -> {
-            lenient().when(optionDetailRepository.findByName(it.getName()))
+            lenient().when(optionDetailRepository.findById(it.getId()))
                     .thenReturn(Optional.of(it));
         });
         given(optionDetailMultipleStockManageService.decrement(anyList(), anyInt()))
                 .willReturn(Result.failure(new BadRequestException("")));
-        var options = optionDetails.stream().map(OptionDetail::getName).toList();
+        var options = optionDetails.stream().map(OptionDetail::getId).toList();
         // when
         // then
         assertThrows(

--- a/src/test/java/com/liberty52/product/service/entity/OrdersEntityTest.java
+++ b/src/test/java/com/liberty52/product/service/entity/OrdersEntityTest.java
@@ -40,9 +40,9 @@ class OrdersEntityTest extends MockS3Test {
     private S3UploaderApi s3Uploader;
 
     private static final String LIBERTY = "Liberty 52_Frame";
-    private static final String OPTION_1 = "이젤 거치형";
-    private static final String OPTION_2 = "1mm 두께 승화전사 인쇄용 알루미늄시트";
-    private static final String OPTION_3 = "유광실버";
+    private static final String OPTION_1 = "OPT-001";
+    private static final String OPTION_2 = "OPT-003";
+    private static final String OPTION_3 = "OPT-004";
     private static final int QUANTITY = 2;
     private static final int DELIVERY_PRICE = PriceConstants.DEFAULT_DELIVERY_PRICE;
 
@@ -74,9 +74,9 @@ class OrdersEntityTest extends MockS3Test {
     private Long getExpectedPrice() {
         long expected = 0;
         expected += productRepository.findByName(LIBERTY).get().getPrice();
-        expected += optionDetailRepository.findByName(OPTION_1).get().getPrice();
-        expected += optionDetailRepository.findByName(OPTION_2).get().getPrice();
-        expected += optionDetailRepository.findByName(OPTION_3).get().getPrice();
+        expected += optionDetailRepository.findById(OPTION_1).get().getPrice();
+        expected += optionDetailRepository.findById(OPTION_2).get().getPrice();
+        expected += optionDetailRepository.findById(OPTION_3).get().getPrice();
         expected *= QUANTITY;
         expected += DELIVERY_PRICE;
         return expected;


### PR DESCRIPTION
## 스프린트 넘버  : 4
## 메이저 마일스톤 : 상품
### 마이너 마일스톤 : 주문
### 백로그 이름 : 주문 요청 시 옵션명이 아닌 옵션ID로 요청하도록 API 수정

Resolve #284 

***
### 작업

**API**
- Request Body에서 `options` -> `optionDetailIds`로 수정.
- API docs. (WIKI)에도 수정 반영 https://github.com/Liberty52/Liberty52/wiki/PRODUCT-API

AS-IS
```
{
  "dto": {
    "productDto": {
      ...
      "options": string[],    // 옵션 이름 배열
     ...
    },
   ...
}
```

TO-BE
```
{
  "dto": {
    "productDto": {
      ...
      "optionDetailIds": string[],    // 옵션 디테일 아이디 배열
     ...
    },
   ...
}
```

**CODE** 
옵션 디테일 fetch code 수정

AS-IS
```java
        List<String> optionDetailIds = dto.getProductDto().getOptions().stream()
                //TODO option detail 조회를 id로 변경되면, 179 - 182를 합칠 수 있음.
                .map(optionName -> optionDetailRepository.findByName(optionName)
                        .orElseThrow(() -> new ResourceNotFoundException(RESOURCE_NAME_OPTION_DETAIL, PARAM_NAME_OPTION_DETAIL_NAME, optionName)))
                .map(OptionDetail::getId)
        // ..중략..
```

TO-BE
```java
        List<String> optionDetailIds = dto.getProductDto().getOptionDetailIds().stream()
                .map(it -> optionDetailRepository.findById(it)
                        .orElseThrow(() -> new ResourceNotFoundException(RESOURCE_NAME_OPTION_DETAIL, PARAM_NAME_OPTION_DETAIL_NAME, it))
                        .getId())
           // .. 중략..
```

**기타 수정사항**
- DBInitConfig에서 생성되는 OptionDetail의 id도 임의 선언적으로 수정 후 저장
- 테스트 코드 수정


***
### 테스트 결과
<img width="519" alt="image" src="https://github.com/Liberty52/product/assets/42243302/59e5e58e-958b-4552-ab6d-58253f638b2b">

***
### 이슈
