### PR TITLE
Product 엔티티 - 라이선스 적용 상품인지 구분 위한 isCustom 속성 추가

### DIFF
--- a/src/main/java/com/liberty52/product/global/config/DBInitConfig.java
+++ b/src/main/java/com/liberty52/product/global/config/DBInitConfig.java
@@ -61,7 +61,7 @@ public class DBInitConfig {
 
         public void init() {
             try {
-                Product product = Product.create(LIBERTY, ProductState.ON_SALE, 100L);
+                Product product = Product.create(LIBERTY, ProductState.ON_SALE, 100L,true);
                 Field id = product.getClass().getDeclaredField("id");
                 id.setAccessible(true);
                 id.set(product, "LIB-001");

--- a/src/main/java/com/liberty52/product/service/entity/Product.java
+++ b/src/main/java/com/liberty52/product/service/entity/Product.java
@@ -27,6 +27,9 @@ public class Product {
     @Column(nullable = false)
     private Long price;
 
+    @Column(nullable=false)
+    private boolean isPremium;
+
     @OneToMany(mappedBy = "product")
     private List<ProductOption> productOptions = new ArrayList<>();
 
@@ -35,10 +38,11 @@ public class Product {
     private String productIntroductionImageUrl;
 
     @Builder
-    private Product(String name, ProductState productState, Long price) {
+    private Product(String name, ProductState productState, Long price, boolean isPremium) {
         this.name = name;
         this.productState = productState;
         this.price = price;
+        this.isPremium = isPremium;
     }
 
     public void createProductIntroduction(String productIntroductionImageUrl) {
@@ -48,10 +52,11 @@ public class Product {
         this.productOptions.add(productOption);
     }
 
-    public static Product create(String name, ProductState state, Long price) {
+    public static Product create(String name, ProductState state, Long price, boolean isPremium) {
         return builder().name(name)
                 .productState(state)
                 .price(price)
+                .isPremium(isPremium)
                 .build();
     }
 

--- a/src/main/java/com/liberty52/product/service/entity/Product.java
+++ b/src/main/java/com/liberty52/product/service/entity/Product.java
@@ -28,7 +28,7 @@ public class Product {
     private Long price;
 
     @Column(nullable=false)
-    private boolean isPremium;
+    private boolean isCustom;
 
     @OneToMany(mappedBy = "product")
     private List<ProductOption> productOptions = new ArrayList<>();
@@ -38,11 +38,11 @@ public class Product {
     private String productIntroductionImageUrl;
 
     @Builder
-    private Product(String name, ProductState productState, Long price, boolean isPremium) {
+    private Product(String name, ProductState productState, Long price, boolean isCustom) {
         this.name = name;
         this.productState = productState;
         this.price = price;
-        this.isPremium = isPremium;
+        this.isCustom = isCustom;
     }
 
     public void createProductIntroduction(String productIntroductionImageUrl) {
@@ -52,11 +52,11 @@ public class Product {
         this.productOptions.add(productOption);
     }
 
-    public static Product create(String name, ProductState state, Long price, boolean isPremium) {
+    public static Product create(String name, ProductState state, Long price, boolean isCustom) {
         return builder().name(name)
                 .productState(state)
                 .price(price)
-                .isPremium(isPremium)
+                .isCustom(isCustom)
                 .build();
     }
 

--- a/src/test/java/com/liberty52/product/service/applicationservice/CartItemRemoveServiceImplTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/CartItemRemoveServiceImplTest.java
@@ -47,7 +47,7 @@ class CartItemRemoveServiceImplTest extends MockS3Test {
 
     @BeforeEach
     void beforeEach() {
-        Product product = MockFactory.createProduct("Liberty 52_Frame", ProductState.ON_SALE, 10_000_000L);
+        Product product = MockFactory.createProduct("Liberty 52_Frame", ProductState.ON_SALE, 10_000_000L,true);
         product = productRepository.save(product);
 
         ProductOption displayOption = MockFactory.createProductOption("거치 방식", true);

--- a/src/test/java/com/liberty52/product/service/applicationservice/ReviewCreateServiceImplTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/ReviewCreateServiceImplTest.java
@@ -71,7 +71,7 @@ class ReviewCreateServiceImplTest extends MockS3Test {
         new FileInputStream(mockImageUrl));
 
     Product product = MockFactory.createProduct("Liberty 52_Frame", ProductState.ON_SALE,
-        10_000_000L);
+        10_000_000L,true);
     productRepository.save(product);
 
     order = MockFactory.createOrder(MOCK_AUTH_ID);

--- a/src/test/java/com/liberty52/product/service/applicationservice/mock/CartItemCreateServiceMockTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/mock/CartItemCreateServiceMockTest.java
@@ -72,7 +72,7 @@ public class CartItemCreateServiceMockTest extends MockS3Test {
 
         given(cartRepository.save(any())).willReturn(Cart.create("testId"));
 
-        given(productRepository.findByName("Liberty 52_Frame")).willReturn(Optional.ofNullable(Product.create("Liberty 52_Frame",ProductState.ON_SALE,100L)));
+        given(productRepository.findByName("Liberty 52_Frame")).willReturn(Optional.ofNullable(Product.create("Liberty 52_Frame",ProductState.ON_SALE,100L,true)));
 
         given(customProductRepository.save(any())).willReturn(null);
         given(customProductOptionRepository.save(any())).willReturn(null);

--- a/src/test/java/com/liberty52/product/service/applicationservice/mock/CartItemRetrieveServiceMockTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/mock/CartItemRetrieveServiceMockTest.java
@@ -49,7 +49,7 @@ public class CartItemRetrieveServiceMockTest extends MockS3Test {
 
     @BeforeEach
     void  init(){
-        Product product = Product.create("Liberty 52_Frame", ProductState.ON_SALE, 100L);
+        Product product = Product.create("Liberty 52_Frame", ProductState.ON_SALE, 100L,true);
 
         ProductOption option1 = ProductOption.create("거치 방식", true, true);
         option1.associate(product);

--- a/src/test/java/com/liberty52/product/service/applicationservice/mock/CartItemSchedulerServiceMockTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/mock/CartItemSchedulerServiceMockTest.java
@@ -63,7 +63,7 @@ public class CartItemSchedulerServiceMockTest extends MockS3Test {
 
     @BeforeEach
     void  init(){
-        Product product = Product.create("Liberty 52_Frame", ProductState.ON_SALE, 100L);
+        Product product = Product.create("Liberty 52_Frame", ProductState.ON_SALE, 100L,true);
 
         ProductOption option1 = ProductOption.create("거치 방식", true, true);
         option1.associate(product);

--- a/src/test/java/com/liberty52/product/service/utils/MockFactory.java
+++ b/src/test/java/com/liberty52/product/service/utils/MockFactory.java
@@ -40,16 +40,16 @@ public class MockFactory {
         return cpo;
     }
 
-    public static Product createProduct(String name, ProductState state, Long price) {
-        return Product.create(name, state, price);
+    public static Product createProduct(String name, ProductState state, Long price, boolean isPremium) {
+        return Product.create(name, state, price, isPremium);
     }
 
     public static Product createProduct(String name) {
-        return createProduct(name, ProductState.ON_SALE, 10_000_000L);
+        return createProduct(name, ProductState.ON_SALE, 10_000_000L, true);
     }
 
     public static Product createProduct(String name, Long price) {
-        return createProduct(name, ProductState.ON_SALE, price);
+        return createProduct(name, ProductState.ON_SALE, price,true);
     }
 
     public static ProductOption createProductOption(String name, boolean require) {


### PR DESCRIPTION
***
### 작업
Product 엔티티에 boolean 타입의 isCustom필드 추가 (true => 작가 라이선스 이미지 사용 불가&개인 이미지 회사 이벤트 라이선스 이미지 사용 및 커스텀 가능, false => 작가 라이선스 이미지 사용 가능(편집 불가))
연관된 테스트코드, DBInit에도 해당 필드 추가 세팅

***
### 테스트 결과
All test passed
<img width="285" alt="image" src="https://github.com/Liberty52/product/assets/96376539/03bcd74d-36aa-4003-a9c9-15e59c5ddcb3">
