### PR TITLE
주문 정보 조회 시 주문배송정보(택배사코드, 택배사이름, 운송장번호) 반환 추가

### DIFF
--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/OrderRetrieveServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/OrderRetrieveServiceImpl.java
@@ -2,6 +2,7 @@ package com.liberty52.product.service.applicationservice.impl;
 
 import com.liberty52.product.global.adapter.cloud.AuthServiceClient;
 import com.liberty52.product.global.exception.external.badrequest.CannotAccessOrderException;
+import com.liberty52.product.global.util.Result;
 import com.liberty52.product.global.util.Validator;
 import com.liberty52.product.service.applicationservice.OrderRetrieveService;
 import com.liberty52.product.service.controller.dto.*;
@@ -80,8 +81,8 @@ public class OrderRetrieveServiceImpl implements OrderRetrieveService {
                 .orElseThrow(CannotAccessOrderException::new);
 
         String customerId = order.getAuthId();
-        String customerName = authServiceClient.retrieveAuthData(Set.of(customerId))
-                .get(customerId).getAuthorName();
+        String customerName = Result.runCatching(() -> authServiceClient.retrieveAuthData(Set.of(customerId))
+                .get(customerId).getAuthorName()).getOrDefault("Unknown");
 
         return OrderDetailRetrieveResponse.of(order, customerName);
     }

--- a/src/main/java/com/liberty52/product/service/controller/dto/AdminCanceledOrderListResponse.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/AdminCanceledOrderListResponse.java
@@ -80,6 +80,8 @@ public class AdminCanceledOrderListResponse {
 
         private static String getProductName(Orders entity) {
             StringBuilder sb = new StringBuilder();
+            if (entity.getCustomProducts().isEmpty())
+                return "";
             sb.append(entity.getCustomProducts().get(0).getProduct().getName());
             if (entity.getCustomProducts().size() > 1) {
                 sb.append(" 외 ").append(entity.getTotalQuantity()).append("건");

--- a/src/main/java/com/liberty52/product/service/controller/dto/AdminOrderListResponse.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/AdminOrderListResponse.java
@@ -77,6 +77,9 @@ public class AdminOrderListResponse {
 
         private static String getProductName(Orders entity) {
             StringBuilder sb = new StringBuilder();
+            if (entity.getCustomProducts().isEmpty()) {
+                return "";
+            }
             sb.append(entity.getCustomProducts().get(0).getProduct().getName());
             if (entity.getCustomProducts().size() > 1) {
                 sb.append(" 외 ").append(entity.getTotalQuantity()).append("건");

--- a/src/main/java/com/liberty52/product/service/controller/dto/OrderDeliveryDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/OrderDeliveryDto.java
@@ -1,0 +1,39 @@
+package com.liberty52.product.service.controller.dto;
+
+import com.liberty52.product.service.entity.OrderDelivery;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderDeliveryDto {
+
+    private String id;
+    private String code;
+    private String name;
+    private String trackingNumber;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static OrderDeliveryDto of(OrderDelivery entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        return OrderDeliveryDto.builder()
+                .id(entity.getId())
+                .code(entity.getCourierCompanyCode())
+                .name(entity.getCourierCompanyName())
+                .trackingNumber(entity.getTrackingNumber())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/liberty52/product/service/controller/dto/OrderDetailRetrieveResponse.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/OrderDetailRetrieveResponse.java
@@ -36,6 +36,7 @@ public class OrderDetailRetrieveResponse {
     private Payment.PaymentInfo paymentInfo;
     private List<OrderRetrieveProductResponse> products;
     private String customerName;
+    private OrderDeliveryDto orderDelivery;
 
     public OrderDetailRetrieveResponse(Orders orders) {
         this.orderId = orders.getId();
@@ -66,6 +67,7 @@ public class OrderDetailRetrieveResponse {
         Payment payment = orders.getPayment();
         this.paymentType = payment.getType().getKorName();
         this.paymentInfo = payment.getInfoAsDto();
+        this.orderDelivery = OrderDeliveryDto.of(orders.getOrderDelivery());
     }
 
     public OrderDetailRetrieveResponse(String orderId, String orderDate, String orderStatus,
@@ -91,6 +93,7 @@ public class OrderDetailRetrieveResponse {
     public static OrderDetailRetrieveResponse of(Orders entity, String customerName) {
         OrderDetailRetrieveResponse response = new OrderDetailRetrieveResponse(entity);
         response.customerName = customerName;
+        response.orderDelivery = OrderDeliveryDto.of(entity.getOrderDelivery());
         return response;
     }
 

--- a/src/main/java/com/liberty52/product/service/controller/dto/OrderDetailRetrieveResponse.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/OrderDetailRetrieveResponse.java
@@ -65,8 +65,10 @@ public class OrderDetailRetrieveResponse {
         this.totalPrice = orders.getAmount();
         this.totalProductPrice = totalPrice - deliveryFee;
         Payment payment = orders.getPayment();
-        this.paymentType = payment.getType().getKorName();
-        this.paymentInfo = payment.getInfoAsDto();
+        if (payment != null) {
+            this.paymentType = payment.getType().getKorName();
+            this.paymentInfo = payment.getInfoAsDto();
+        }
         this.orderDelivery = OrderDeliveryDto.of(orders.getOrderDelivery());
     }
 

--- a/src/main/java/com/liberty52/product/service/controller/dto/OrdersRetrieveResponse.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/OrdersRetrieveResponse.java
@@ -45,8 +45,10 @@ public class OrdersRetrieveResponse {
         this.productRepresentUrl = LIBERTY52_FRAME_REPRESENTATIVE_URL;
         this.orderNum = orders.getOrderNum();
         Payment payment = orders.getPayment();
-        this.paymentType = payment.getType().getKorName();
-        this.paymentInfo = payment.getInfoAsDto();
+        if (payment != null) {
+            this.paymentType = payment.getType().getKorName();
+            this.paymentInfo = payment.getInfoAsDto();
+        }
         this.products = orders.getCustomProducts().stream().map(c ->
                 new OrderRetrieveProductResponse(c.getId(),c.getProduct().getName(), c.getQuantity(),
                         c.getProduct().getPrice() + c.getOptions()

--- a/src/main/java/com/liberty52/product/service/entity/Orders.java
+++ b/src/main/java/com/liberty52/product/service/entity/Orders.java
@@ -4,10 +4,7 @@ import com.liberty52.product.global.constants.PriceConstants;
 import com.liberty52.product.global.util.Utils;
 import com.liberty52.product.service.entity.payment.Payment;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -17,10 +14,10 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
-@Slf4j
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Orders {
 
     @Id
@@ -36,9 +33,9 @@ public class Orders {
 
     private int deliveryPrice = PriceConstants.DEFAULT_DELIVERY_PRICE;
 
-    private Long amount;
+    private Long amount = 0L;
 
-    private Integer totalQuantity;
+    private Integer totalQuantity = 0;
 
     private String orderNum;
 

--- a/src/main/java/com/liberty52/product/service/repository/OrderQueryDslRepositoryImpl.java
+++ b/src/main/java/com/liberty52/product/service/repository/OrderQueryDslRepositoryImpl.java
@@ -23,6 +23,7 @@ import static com.liberty52.product.service.entity.QCanceledOrders.canceledOrder
 import static com.liberty52.product.service.entity.QCustomProduct.customProduct;
 import static com.liberty52.product.service.entity.QCustomProductOption.customProductOption;
 import static com.liberty52.product.service.entity.QOptionDetail.optionDetail;
+import static com.liberty52.product.service.entity.QOrderDelivery.orderDelivery;
 import static com.liberty52.product.service.entity.QOrderDestination.orderDestination;
 import static com.liberty52.product.service.entity.QOrders.orders;
 import static com.liberty52.product.service.entity.QProduct.product;
@@ -122,7 +123,8 @@ public class OrderQueryDslRepositoryImpl implements OrderQueryDslRepository {
                 .leftJoin(product).on(customProduct.product.eq(product)).fetchJoin()
                 .leftJoin(customProductOption).on(customProductOption.customProduct.eq(customProduct)).fetchJoin()
                 .leftJoin(optionDetail).on(customProductOption.optionDetail.eq(optionDetail)).fetchJoin()
-                .leftJoin(payment).on(payment.orders.eq(orders)).fetchJoin();
+                .leftJoin(payment).on(payment.orders.eq(orders)).fetchJoin()
+                .leftJoin(orderDelivery).on(orderDelivery.order.eq(orders)).fetchJoin();
     }
 
     private JPAQuery<Orders> fetchOrdersByAdmin(Pageable pageable) {

--- a/src/main/java/com/liberty52/product/service/repository/OrderQueryDslRepositoryImpl.java
+++ b/src/main/java/com/liberty52/product/service/repository/OrderQueryDslRepositoryImpl.java
@@ -9,6 +9,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -222,6 +223,7 @@ public class OrderQueryDslRepositoryImpl implements OrderQueryDslRepository {
     }
 
     @Getter
+    @Builder
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     public static class PageInfo {
         private Long startPage;

--- a/src/test/java/com/liberty52/product/service/applicationservice/impl/OrderRetrieveServiceImplTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/impl/OrderRetrieveServiceImplTest.java
@@ -1,0 +1,358 @@
+package com.liberty52.product.service.applicationservice.impl;
+
+import com.liberty52.product.global.adapter.cloud.AuthServiceClient;
+import com.liberty52.product.service.controller.dto.AuthClientDataResponse;
+import com.liberty52.product.service.entity.CanceledOrders;
+import com.liberty52.product.service.entity.OrderStatus;
+import com.liberty52.product.service.entity.Orders;
+import com.liberty52.product.service.repository.OrderQueryDslRepository;
+import com.liberty52.product.service.repository.OrderQueryDslRepositoryImpl;
+import com.liberty52.product.service.utils.MockFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class OrderRetrieveServiceImplTest {
+
+    @InjectMocks
+    private OrderRetrieveServiceImpl service;
+
+    @Mock
+    private OrderQueryDslRepository orderQueryDslRepository;
+
+    @Mock
+    private AuthServiceClient authServiceClient;
+
+    @Test
+    @DisplayName("유저가 주문 리스트를 조회한다")
+    void retrieveOrders() {
+        var orders = new ArrayList<Orders>();
+        for (int i = 0; i < 100; i++) {
+            orders.add(MockFactory.createOrder("1"));
+        }
+        given(orderQueryDslRepository.retrieveOrders(anyString()))
+                .willReturn(orders);
+
+        var result = service.retrieveOrders("1");
+
+        assertFalse(result.isEmpty());
+        assertEquals(100, result.size());
+        orders.forEach(it -> assertEquals("1", it.getAuthId()));
+    }
+
+    @Test
+    @DisplayName("유저가 주문 상세정보를 조회한다")
+    void retrieveOrderDetail() {
+        var order = MockFactory.createOrder("1");
+        given(orderQueryDslRepository.retrieveOrderDetail("1", order.getId()))
+                .willReturn(Optional.of(order));
+
+        var result = service.retrieveOrderDetail("1", order.getId());
+
+        assertNotNull(result);
+        assertEquals(order.getId(), result.getOrderId());
+        assertEquals(order.getOrderNum(), result.getOrderNum());
+    }
+
+    @Test
+    @DisplayName("익명유저가 주문 상세정보를 조회한다")
+    void retrieveGuestOrderDetail() {
+        var order = MockFactory.createOrder("G-1");
+        given(orderQueryDslRepository.retrieveGuestOrderDetail(anyString(), anyString()))
+                .willReturn(Optional.of(order));
+
+        var result = service.retrieveGuestOrderDetail("G-1", "ordernum");
+
+        assertNotNull(result);
+        assertEquals(order.getId(), result.getOrderId());
+        assertEquals(order.getOrderNum(), result.getOrderNum());
+    }
+
+    @Test
+    @DisplayName("관리자가 주문 리스트를 조회한다")
+    void retrieveOrdersByAdmin() {
+        var orders = new ArrayList<Orders>();
+        var random = new Random();
+        for (int i = 0; i < 100; i++) {
+            var authId = random.nextInt(10) + 1;
+            orders.add(MockFactory.createOrder(String.valueOf(authId)));
+        }
+        given(orderQueryDslRepository.retrieveOrdersByAdmin(any(Pageable.class)))
+                .willReturn(orders);
+
+        var pageInfo = OrderQueryDslRepositoryImpl.PageInfo.builder()
+                .startPage(1L)
+                .currentPage(1L)
+                .lastPage(100L)
+                .totalLastPage(100L)
+                .build();
+        given(orderQueryDslRepository.getPageInfo(any(Pageable.class)))
+                .willReturn(pageInfo);
+
+        var customerInfos = new HashMap<String, AuthClientDataResponse>();
+        orders.forEach(it ->
+                customerInfos.put(it.getAuthId(), new AuthClientDataResponse("name_" + it.getAuthId(), null)));
+        given(authServiceClient.retrieveAuthData(anySet()))
+                .willReturn(customerInfos);
+
+        var result = service.retrieveOrdersByAdmin("ADMIN", PageRequest.of(0, 10));
+
+        assertNotNull(result);
+        assertEquals(100, result.getOrders().size());
+        assertEquals(1L, result.getStartPage());
+        assertEquals(1L, result.getCurrentPage());
+        assertEquals(100L, result.getLastPage());
+        assertEquals(100L, result.getTotalLastPage());
+        for (int i = 0; i < result.getOrders().size(); i++) {
+            var expect = orders.get(i);
+            var actual = result.getOrders().get(i);
+            assertEquals(expect.getId(), actual.getOrderId());
+            assertEquals(expect.getAuthId(), actual.getCustomerId());
+            assertEquals("name_"+expect.getAuthId(), actual.getCustomerName());
+        }
+    }
+
+    @Test
+    @DisplayName("관리자가 주문 리스트를 조회할 경우 리스트가 비어있다면 비어있는 응답값을 조회한다")
+    void retrieveOrdersByAdmin_noResult() {
+        given(orderQueryDslRepository.retrieveOrdersByAdmin(any(Pageable.class)))
+                .willReturn(new ArrayList<>());
+
+        var result = service.retrieveOrdersByAdmin("ADMIN", PageRequest.of(0, 10));
+
+        assertNotNull(result);
+        assertTrue(result.getOrders().isEmpty());
+        assertEquals(0L, result.getStartPage());
+        assertEquals(0L, result.getCurrentPage());
+        assertEquals(0L, result.getLastPage());
+        assertEquals(0L, result.getTotalLastPage());
+    }
+
+    @Test
+    @DisplayName("관리자가 주문 상세정보를 조회한다")
+    void retrieveOrderDetailByAdmin() {
+        var order = MockFactory.createOrder("1");
+        given(orderQueryDslRepository.retrieveOrderDetailByOrderId(anyString()))
+                .willReturn(Optional.of(order));
+
+        var customerInfos = new HashMap<String, AuthClientDataResponse>();
+        customerInfos.put("1", new AuthClientDataResponse("name_1", null));
+        given(authServiceClient.retrieveAuthData(anySet()))
+                .willReturn(customerInfos);
+
+        var result = service.retrieveOrderDetailByAdmin("ADMIN", order.getId());
+
+        assertNotNull(result);
+        assertEquals(order.getId(), result.getOrderId());
+        assertEquals("name_1", result.getCustomerName());
+    }
+
+    @Test
+    @DisplayName("관리자가 취소 주문 또는 취소 요청 주문 리스트를 조회한다")
+    void retrieveCanceledOrdersByAdmin() {
+        var orders = new ArrayList<Orders>();
+        var random = new Random();
+        for (int i = 0; i < 100; i++) {
+            var authId = random.nextInt(10) + 1;
+            var order = MockFactory.createOrder(String.valueOf(authId));
+            if (i % 2 == 0) {
+                order.changeOrderStatusToCanceled();
+            } else {
+                order.changeOrderStatusToCancelRequest();
+            }
+            order.changeOrderStatusToCanceled();
+            CanceledOrders.of("", order);
+            orders.add(order);
+        }
+        given(orderQueryDslRepository.retrieveCanceledOrdersByAdmin(any(Pageable.class)))
+                .willReturn(orders);
+
+        var pageInfo = OrderQueryDslRepositoryImpl.PageInfo.builder()
+                .startPage(1L)
+                .currentPage(1L)
+                .lastPage(100L)
+                .totalLastPage(100L)
+                .build();
+        given(orderQueryDslRepository.getCanceledOrdersPageInfo(any(Pageable.class), any()))
+                .willReturn(pageInfo);
+
+        var customerInfos = new HashMap<String, AuthClientDataResponse>();
+        orders.forEach(it ->
+                customerInfos.put(it.getAuthId(), new AuthClientDataResponse("name_" + it.getAuthId(), null)));
+        given(authServiceClient.retrieveAuthData(anySet()))
+                .willReturn(customerInfos);
+
+        var result = service.retrieveCanceledOrdersByAdmin("ADMIN", PageRequest.of(1, 100));
+
+        assertNotNull(result);
+        assertFalse(result.getOrders().isEmpty());
+        assertEquals(100, result.getOrders().size());
+        assertEquals(1L, result.getStartPage());
+        assertEquals(1L, result.getCurrentPage());
+        assertEquals(100L, result.getLastPage());
+        assertEquals(100L, result.getTotalLastPage());
+        for (int i = 0; i < result.getOrders().size(); i++) {
+            var expect = orders.get(i);
+            var actual = result.getOrders().get(i);
+            assertEquals(expect.getId(), actual.getOrderId());
+            assertEquals(expect.getAuthId(), actual.getCustomerId());
+            assertEquals("name_"+expect.getAuthId(), actual.getCustomerName());
+            assertTrue(
+                    OrderStatus.CANCELED.getKoName().equals(actual.getOrderStatus()) ||
+                            OrderStatus.CANCEL_REQUESTED.getKoName().equals(actual.getOrderStatus())
+            );
+        }
+    }
+
+    @Test
+    @DisplayName("관리자가 취소 주문 또는 취소 요청 주문 리스트를 조회할 경우 리스트가 비어있다면 비어있는 응답값을 반환한다")
+    void retrieveCanceledOrdersByAdmin_noResult() {
+        given(orderQueryDslRepository.retrieveCanceledOrdersByAdmin(any(Pageable.class)))
+                .willReturn(new ArrayList<>());
+
+        var result = service.retrieveCanceledOrdersByAdmin("ADMIN", PageRequest.of(1, 100));
+
+        assertNotNull(result);
+        assertTrue(result.getOrders().isEmpty());
+        assertEquals(0L, result.getStartPage());
+        assertEquals(0L, result.getCurrentPage());
+        assertEquals(0L, result.getLastPage());
+        assertEquals(0L, result.getTotalLastPage());
+    }
+
+    @Test
+    @DisplayName("관리자가 취소 요청 주문 리스트를 조회한다")
+    void retrieveOnlyRequestedCanceledOrdersByAdmin() {
+        var orders = new ArrayList<Orders>();
+        var random = new Random();
+        for (int i = 0; i < 100; i++) {
+            var authId = random.nextInt(10) + 1;
+            var order = MockFactory.createOrder(String.valueOf(authId));
+            order.changeOrderStatusToCancelRequest();
+            CanceledOrders.of("", order);
+            orders.add(order);
+        }
+        given(orderQueryDslRepository.retrieveOnlyRequestedCanceledOrdersByAdmin(any(Pageable.class)))
+                .willReturn(orders);
+
+        var pageInfo = OrderQueryDslRepositoryImpl.PageInfo.builder()
+                .startPage(1L)
+                .currentPage(1L)
+                .lastPage(100L)
+                .totalLastPage(100L)
+                .build();
+        given(orderQueryDslRepository.getCanceledOrdersPageInfo(any(Pageable.class), any()))
+                .willReturn(pageInfo);
+
+        var customerInfos = new HashMap<String, AuthClientDataResponse>();
+        orders.forEach(it ->
+                customerInfos.put(it.getAuthId(), new AuthClientDataResponse("name_" + it.getAuthId(), null)));
+        given(authServiceClient.retrieveAuthData(anySet()))
+                .willReturn(customerInfos);
+
+        var result = service.retrieveOnlyRequestedCanceledOrdersByAdmin("ADMIN", PageRequest.of(1, 100));
+
+        assertNotNull(result);
+        assertFalse(result.getOrders().isEmpty());
+        assertEquals(100, result.getOrders().size());
+        assertEquals(1L, result.getStartPage());
+        assertEquals(1L, result.getCurrentPage());
+        assertEquals(100L, result.getLastPage());
+        assertEquals(100L, result.getTotalLastPage());
+        for (int i = 0; i < result.getOrders().size(); i++) {
+            var expect = orders.get(i);
+            var actual = result.getOrders().get(i);
+            assertEquals(expect.getId(), actual.getOrderId());
+            assertEquals(expect.getAuthId(), actual.getCustomerId());
+            assertEquals("name_"+expect.getAuthId(), actual.getCustomerName());
+            assertEquals(OrderStatus.CANCEL_REQUESTED.getKoName(), actual.getOrderStatus());
+        }
+    }
+
+    @Test
+    @DisplayName("관리자가 취소 주문 리스트를 조회한다")
+    void retrieveOnlyCanceledOrdersByAdmin() {
+        var orders = new ArrayList<Orders>();
+        var random = new Random();
+        for (int i = 0; i < 100; i++) {
+            var authId = random.nextInt(10) + 1;
+            var order = MockFactory.createOrder(String.valueOf(authId));
+            order.changeOrderStatusToCanceled();
+            CanceledOrders.of("", order);
+            orders.add(order);
+        }
+        given(orderQueryDslRepository.retrieveOnlyCanceledOrdersByAdmin(any(Pageable.class)))
+                .willReturn(orders);
+
+        var pageInfo = OrderQueryDslRepositoryImpl.PageInfo.builder()
+                .startPage(1L)
+                .currentPage(1L)
+                .lastPage(100L)
+                .totalLastPage(100L)
+                .build();
+        given(orderQueryDslRepository.getCanceledOrdersPageInfo(any(Pageable.class), any()))
+                .willReturn(pageInfo);
+
+        var customerInfos = new HashMap<String, AuthClientDataResponse>();
+        orders.forEach(it ->
+                customerInfos.put(it.getAuthId(), new AuthClientDataResponse("name_" + it.getAuthId(), null)));
+        given(authServiceClient.retrieveAuthData(anySet()))
+                .willReturn(customerInfos);
+
+        var result = service.retrieveOnlyCanceledOrdersByAdmin("ADMIN", PageRequest.of(1, 100));
+
+        assertNotNull(result);
+        assertFalse(result.getOrders().isEmpty());
+        assertEquals(100, result.getOrders().size());
+        assertEquals(1L, result.getStartPage());
+        assertEquals(1L, result.getCurrentPage());
+        assertEquals(100L, result.getLastPage());
+        assertEquals(100L, result.getTotalLastPage());
+        for (int i = 0; i < result.getOrders().size(); i++) {
+            var expect = orders.get(i);
+            var actual = result.getOrders().get(i);
+            assertEquals(expect.getId(), actual.getOrderId());
+            assertEquals(expect.getAuthId(), actual.getCustomerId());
+            assertEquals("name_"+expect.getAuthId(), actual.getCustomerName());
+            assertEquals(OrderStatus.CANCELED.getKoName(), actual.getOrderStatus());
+        }
+    }
+
+    @Test
+    @DisplayName("관리자가 취소 주문 상세정보를 조회한다")
+    void retrieveCanceledOrderDetailByAdmin() {
+        var order = MockFactory.createOrder("1");
+        order.changeOrderStatusToCanceled();
+        CanceledOrders.of("reason", order);
+        given(orderQueryDslRepository.retrieveOrderDetailWithCanceledOrdersByAdmin(anyString()))
+                .willReturn(Optional.of(order));
+
+        var customerInfo = new HashMap<String, AuthClientDataResponse>();
+        customerInfo.put("1", new AuthClientDataResponse("name_1", null));
+        given(authServiceClient.retrieveAuthData(anySet()))
+                .willReturn(customerInfo);
+
+        var result = service.retrieveCanceledOrderDetailByAdmin("ADMIN", order.getId());
+
+        assertNotNull(result);
+        assertEquals(order.getId(), result.getBasicOrderDetail().getOrderId());
+        assertEquals(OrderStatus.CANCELED.getKoName(), result.getBasicOrderDetail().getOrderStatus());
+        assertEquals("reason", result.getCanceledInfo().getReason());
+        assertNotNull(result.getCanceledInfo().getCanceledAt());
+    }
+}

--- a/src/test/java/com/liberty52/product/service/controller/OrderControllerTest.java
+++ b/src/test/java/com/liberty52/product/service/controller/OrderControllerTest.java
@@ -19,14 +19,15 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import java.util.Collections;
-import java.util.List;
 
 @WebMvcTest(OrderController.class)
 class OrderControllerTest {
@@ -97,6 +98,14 @@ class OrderControllerTest {
                 .paymentInfo(null)
                 .products(Collections.emptyList())
                 .customerName("John Doe")
+                .orderDelivery(OrderDeliveryDto.builder()
+                        .id("od-id")
+                        .code("01")
+                        .name("택배사")
+                        .trackingNumber("1234567890")
+                        .createdAt(LocalDateTime.now())
+                        .updatedAt(LocalDateTime.now())
+                        .build())
                 .build();
 
         given(orderRetrieveService.retrieveOrderDetail(anyString(), anyString()))
@@ -121,7 +130,13 @@ class OrderControllerTest {
                 .andExpect(jsonPath("$.paymentType").value("Card"))
                 .andExpect(jsonPath("$.paymentInfo").doesNotExist())
                 .andExpect(jsonPath("$.products").isArray())
-                .andExpect(jsonPath("$.customerName").value("John Doe"));
+                .andExpect(jsonPath("$.customerName").value("John Doe"))
+                .andExpect(jsonPath("$.orderDelivery.id").value("od-id"))
+                .andExpect(jsonPath("$.orderDelivery.code").value("01"))
+                .andExpect(jsonPath("$.orderDelivery.name").value("택배사"))
+                .andExpect(jsonPath("$.orderDelivery.trackingNumber").value("1234567890"))
+                .andExpect(jsonPath("$.orderDelivery.createdAt").isNotEmpty())
+                .andExpect(jsonPath("$.orderDelivery.updatedAt").isNotEmpty());
     }
 
     @Test

--- a/src/test/java/com/liberty52/product/service/repository/OrdersTest.java
+++ b/src/test/java/com/liberty52/product/service/repository/OrdersTest.java
@@ -2,8 +2,6 @@ package com.liberty52.product.service.repository;
 
 import com.liberty52.product.service.entity.OrderDestination;
 import com.liberty52.product.service.entity.Orders;
-import com.liberty52.product.service.repository.OrdersRepository;
-import com.netflix.discovery.converters.Auto;
 import jakarta.persistence.EntityManager;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -22,7 +20,7 @@ public class OrdersTest {
     void ordersAssociationWithOrderDestination () throws Exception{
         //given
         OrderDestination destination = OrderDestination.create("김", "kghdasd@naver.com", "", "", "", "");
-        Orders orders = Orders.create("", 1000, destination);
+        Orders orders = Orders.create("", destination);
         String id = orders.getId();
         ordersRepository.save(orders);
         em.flush();


### PR DESCRIPTION
## 스프린트 넘버  : 5
## 메이저 마일스톤 : 상품
### 마이너 마일스톤 : 주문조회
### 백로그 이름 : 주문 정보 조회 시 주문배송정보(택배사코드, 택배사이름, 운송장번호) 반환 추가

Resolve #306 

***
### 작업

기존 유저 및 관리자의 주문 상세정보 조회 API의 응답값에 주문배송정보(`orderDelivery`) 프로퍼티를 추가하였습니다.

또한, `OrderRetrieveService`에 대한 단위 테스트코드가 없어서 추가하였습니다.

***
### 테스트 결과
<img width="365" alt="image" src="https://github.com/Liberty52/product/assets/42243302/73ca42a3-d0eb-43be-bdba-5cc1cce49bc6">


***
### 이슈
