### PR TITLE
refactor: PortOne WebClient 빈 위치 변경

### DIFF
--- a/src/main/java/com/liberty52/product/global/adapter/portone/PortOneRequestClient.java
+++ b/src/main/java/com/liberty52/product/global/adapter/portone/PortOneRequestClient.java
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liberty52.product.global.adapter.portone.dto.*;
 import com.liberty52.product.global.adapter.portone.exception.PortOne4xxResponseException;
 import com.liberty52.product.global.adapter.portone.exception.PortOneErrorException;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
@@ -19,14 +19,24 @@ import java.util.Objects;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class PortOneRequestClient {
 
-    @Value("${portone.api-key}")
-    private String PORT_ONE_API_KEY;
-    @Value("${portone.secret-key}")
-    private String PORT_ONE_SECRET_KEY;
+    private final String PORT_ONE_API_KEY;
+    private final String PORT_ONE_SECRET_KEY;
     private final WebClient webClient;
+
+    public PortOneRequestClient(
+            @Value("${portone.api-key}")
+            String apiKey,
+            @Value("${portone.secret-key}")
+            String secretKey,
+            @Qualifier(value = "portOneWebClient")
+            WebClient webClient
+    ) {
+        this.PORT_ONE_API_KEY = apiKey;
+        this.PORT_ONE_SECRET_KEY = secretKey;
+        this.webClient = webClient;
+    }
 
     public PortOneToken getAccessToken() {
         try {

--- a/src/main/java/com/liberty52/product/global/adapter/portone/config/PortOneWebClientFactory.java
+++ b/src/main/java/com/liberty52/product/global/adapter/portone/config/PortOneWebClientFactory.java
@@ -1,0 +1,37 @@
+package com.liberty52.product.global.adapter.portone.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+@Configuration
+public class PortOneWebClientFactory {
+    @Bean(value = "portOneWebClient")
+    @SuppressWarnings("deprecation")
+    public WebClient webClient() {
+        HttpClient httpClient = HttpClient.create()
+                .tcpConfiguration(
+                        client -> client.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 3000) //miliseconds
+                                .doOnConnected(
+                                        conn -> conn.addHandlerLast(new ReadTimeoutHandler(5))  //sec
+                                                .addHandlerLast(new WriteTimeoutHandler(60)) //sec
+                                )
+                );
+
+        return WebClient.builder()
+                .baseUrl("https://api.iamport.kr")
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .defaultHeaders(httpHeaders -> {
+                    httpHeaders.set(HttpHeaders.CONTENT_TYPE, "application/json");
+                    httpHeaders.set(HttpHeaders.ACCEPT_CHARSET, "UTF-8");
+                    httpHeaders.set(HttpHeaders.ACCEPT, "*/*");
+                })
+                .build();
+    }
+}

--- a/src/main/java/com/liberty52/product/global/config/BeanConfig.java
+++ b/src/main/java/com/liberty52/product/global/config/BeanConfig.java
@@ -1,45 +1,11 @@
 package com.liberty52.product.global.config;
 
-import io.netty.channel.ChannelOption;
-import io.netty.handler.timeout.ReadTimeoutHandler;
-import io.netty.handler.timeout.WriteTimeoutHandler;
 import org.modelmapper.ModelMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.client.reactive.ReactorClientHttpConnector;
-import org.springframework.web.reactive.function.client.WebClient;
-import reactor.netty.http.client.HttpClient;
 
 @Configuration
 public class BeanConfig {
-
-    /**
-     * PortOne API를 호출하는 WebClient.
-     */
-    @Bean
-    @SuppressWarnings("deprecation")
-    public WebClient webClient() {
-        HttpClient httpClient = HttpClient.create()
-                .tcpConfiguration(
-                        client -> client.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 3000) //miliseconds
-                                .doOnConnected(
-                                        conn -> conn.addHandlerLast(new ReadTimeoutHandler(5))  //sec
-                                                .addHandlerLast(new WriteTimeoutHandler(60)) //sec
-                                )
-                );
-
-        return WebClient.builder()
-                .baseUrl("https://api.iamport.kr")
-                .clientConnector(new ReactorClientHttpConnector(httpClient))
-                .defaultHeaders(httpHeaders -> {
-                    httpHeaders.set(HttpHeaders.CONTENT_TYPE, "application/json");
-                    httpHeaders.set(HttpHeaders.ACCEPT_CHARSET, "UTF-8");
-                    httpHeaders.set(HttpHeaders.ACCEPT, "*/*");
-                })
-                .build();
-    }
-
 
     //Dto<->Entity Mapper
     @Bean

--- a/src/test/java/com/liberty52/product/ProductApplicationTests.java
+++ b/src/test/java/com/liberty52/product/ProductApplicationTests.java
@@ -2,10 +2,8 @@ package com.liberty52.product;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootTest
-@ComponentScan
 class ProductApplicationTests {
 
 	@Test


### PR DESCRIPTION
## 스프린트 넘버  : 5
## 메이저 마일스톤 :
### 마이너 마일스톤 :
### 백로그 이름 :

Resolve #313 

***
### 작업

`PortOne`에서 사용하는 WebClient 빈이 `global.config.BeanConfig` 안에서 초기화하였는데, 
이 때문에 다른 WebClient 빈을 바로 사용하기에 제약이 발생할 것으로 예상된다. 
따라서 이를 `adapter.portone.config.PortOneWebClientFactory`라는 설정 클래스로 이관하였다.


***
### 테스트 결과
<img width="267" alt="image" src="https://github.com/Liberty52/product/assets/42243302/88a820cb-c029-4052-963d-9b6499356243">


***
### 이슈
