### PR TITLE
refactor: Main 클래스 configuration 어노테이션 분리

### DIFF
--- a/src/main/java/com/liberty52/product/ProductApplication.java
+++ b/src/main/java/com/liberty52/product/ProductApplication.java
@@ -5,20 +5,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.core.env.Environment;
-import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Optional;
 
-@EnableAsync
-@EnableScheduling
-@SpringBootApplication
-@EnableFeignClients
 @Slf4j
+@SpringBootApplication
 public class ProductApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/liberty52/product/global/config/FeignClientConfig.java
+++ b/src/main/java/com/liberty52/product/global/config/FeignClientConfig.java
@@ -2,10 +2,12 @@ package com.liberty52.product.global.config;
 
 import com.liberty52.product.global.adapter.cloud.error.FeignClientErrorDecoder;
 import feign.codec.ErrorDecoder;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@EnableFeignClients(basePackages = "com.liberty52")
 public class FeignClientConfig {
 
     @Bean

--- a/src/main/java/com/liberty52/product/global/config/SchedulerConfig.java
+++ b/src/main/java/com/liberty52/product/global/config/SchedulerConfig.java
@@ -4,6 +4,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.SchedulingConfigurer;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
@@ -12,6 +14,8 @@ import java.util.concurrent.Executor;
 
 @Slf4j
 @Configuration
+@EnableAsync
+@EnableScheduling
 public class SchedulerConfig implements AsyncConfigurer, SchedulingConfigurer {
 
     public ThreadPoolTaskScheduler customThreadPoolTaskScheduler() {


### PR DESCRIPTION
## 스프린트 넘버  : 5
## 메이저 마일스톤 :
### 마이너 마일스톤 :
### 백로그 이름 :

Resolve #315 

***
### 작업

Main 클래스의 어노테이션으로 설정되어 있는 여러 configuration을 각 config 클래스로 이관

***
### 테스트 결과
<img width="259" alt="image" src="https://github.com/Liberty52/product/assets/42243302/f9c0102d-3a25-43a3-ba13-02a635d3dab6">


***
### 이슈
