### PR TITLE
hotfix: 주문배송정보 추가 시 중복추가 문제 해결

### DIFF
--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/OrderDeliveryServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/OrderDeliveryServiceImpl.java
@@ -61,13 +61,9 @@ public class OrderDeliveryServiceImpl implements OrderDeliveryService {
         var order = ordersRepository.findById(orderId)
                 .orElseThrow(() -> new ResourceNotFoundException("order", "id", orderId));
 
-        var orderDelivery = OrderDelivery.builder()
-                .courierCompanyCode(dto.courierCompanyCode())
-                .courierCompanyName(dto.courierCompanyName())
-                .trackingNumber(dto.trackingNumber())
-                .order(order)
-                .build();
-        order.setOrderDelivery(orderDelivery);
+        var orderDelivery = (order.getOrderDelivery() == null) ?
+                OrderDelivery.of(dto.courierCompanyCode(), dto.courierCompanyName(), dto.trackingNumber(), order) :
+                order.getOrderDelivery().update(dto.courierCompanyCode(), dto.courierCompanyName(), dto.trackingNumber());
 
         return AdminAddOrderDeliveryDto.Response.builder()
                 .orderId(order.getId())

--- a/src/main/java/com/liberty52/product/service/entity/OrderDelivery.java
+++ b/src/main/java/com/liberty52/product/service/entity/OrderDelivery.java
@@ -43,6 +43,23 @@ public class OrderDelivery {
     @JoinColumn(name = "order_id")
     private Orders order;
 
+    public static OrderDelivery of(String courierCompanyCode, String courierCompanyName, String trackingNumber, Orders order) {
+        var instance = OrderDelivery.builder()
+                .courierCompanyCode(courierCompanyCode)
+                .courierCompanyName(courierCompanyName)
+                .trackingNumber(trackingNumber)
+                .build();
+        instance.associate(order);
+        return instance;
+    }
+
+    public OrderDelivery update(String courierCompanyCode, String courierCompanyName, String trackingNumber) {
+        this.courierCompanyCode = courierCompanyCode;
+        this.courierCompanyName = courierCompanyName;
+        this.trackingNumber = trackingNumber;
+        return this;
+    }
+
     public void associate(Orders order) {
         this.order = order;
         order.setOrderDelivery(this);

--- a/src/test/java/com/liberty52/product/service/applicationservice/impl/OrderDeliveryServiceImplTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/impl/OrderDeliveryServiceImplTest.java
@@ -186,6 +186,37 @@ class OrderDeliveryServiceImplTest {
     }
 
     @Test
+    void 주문의_주문배송정보가_이미_존재할_경우_주문배송정보를_수정한다() {
+        // given
+        var request = AdminAddOrderDeliveryDto.Request.builder()
+                .courierCompanyCode("01")
+                .courierCompanyName("courier")
+                .trackingNumber("1234567890")
+                .build();
+
+        var companyList = new ArrayList<SmartCourierCompanyListDto.CompanyResponse>();
+        companyList.add(new SmartCourierCompanyListDto.CompanyResponse(
+                false, "01", "courier"
+        ));
+        var courierCompanyList = new SmartCourierCompanyListDto(companyList);
+        given(client.getCourierCompanyList())
+                .willReturn(courierCompanyList.asMap());
+
+        var order = MockFactory.createOrder("1");
+        MockFactory.orderDelivery("04", "o_name", "o_tn", order);
+        given(ordersRepository.findById(anyString()))
+                .willReturn(Optional.of(order));
+        // when
+        var result = service.add(order.getId(), request);
+        // then
+        assertNotNull(result);
+        assertEquals(order.getId(), result.orderId());
+        assertEquals(request.courierCompanyCode(), result.courierCompanyCode());
+        assertEquals(request.courierCompanyName(), result.courierCompanyName());
+        assertEquals(request.trackingNumber(), result.trackingNumber());
+    }
+
+    @Test
     void 택배사코드_없이_주문배송정보를_추가할_수_없다() {
         // given
         var request = AdminAddOrderDeliveryDto.Request.builder()


### PR DESCRIPTION
Resolve #333 

***
### 작업

문제: 주문배송정보 (배송시작 시 등록하는 운송장번호) 추가 시 중복체크를 하지 않음에 따라 중복 저장하게 된다.

해결: 수정 API를 별도로 구현하지는 않고, 추가(등록) API 호출 시 주문배송정보가 존재할 경우 수정하도록 하였다.
