### PR TITLE
[관리자] 상품별 택배사/배송비 관련 API 추가

### DIFF
--- a/src/main/java/com/liberty52/product/service/applicationservice/ProductDeliveryOptionService.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/ProductDeliveryOptionService.java
@@ -1,0 +1,22 @@
+package com.liberty52.product.service.applicationservice;
+
+import com.liberty52.product.service.controller.dto.AdminProductDeliveryOptionsDto;
+
+public interface ProductDeliveryOptionService {
+    AdminProductDeliveryOptionsDto.Response create(
+            String role,
+            String productId,
+            AdminProductDeliveryOptionsDto.Request dto
+    );
+
+    AdminProductDeliveryOptionsDto.Response getByProductId(
+            String role,
+            String productId
+    );
+
+    AdminProductDeliveryOptionsDto.Response update(
+            String role,
+            String productId,
+            AdminProductDeliveryOptionsDto.Request dto
+    );
+}

--- a/src/main/java/com/liberty52/product/service/applicationservice/ProductDeliveryOptionService.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/ProductDeliveryOptionService.java
@@ -9,7 +9,7 @@ public interface ProductDeliveryOptionService {
             AdminProductDeliveryOptionsDto.Request dto
     );
 
-    AdminProductDeliveryOptionsDto.Response getByProductId(
+    AdminProductDeliveryOptionsDto.Response getByProductIdForAdmin(
             String role,
             String productId
     );

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/ProductDeliveryOptionServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/ProductDeliveryOptionServiceImpl.java
@@ -1,0 +1,67 @@
+package com.liberty52.product.service.applicationservice.impl;
+
+import com.liberty52.product.global.exception.external.badrequest.BadRequestException;
+import com.liberty52.product.global.exception.external.notfound.ResourceNotFoundException;
+import com.liberty52.product.global.util.Validator;
+import com.liberty52.product.service.applicationservice.ProductDeliveryOptionService;
+import com.liberty52.product.service.controller.dto.AdminProductDeliveryOptionsDto;
+import com.liberty52.product.service.entity.ProductDeliveryOption;
+import com.liberty52.product.service.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProductDeliveryOptionServiceImpl implements ProductDeliveryOptionService {
+
+    private final ProductRepository productRepository;
+
+    @Override
+    @Transactional
+    public AdminProductDeliveryOptionsDto.Response create(
+            String role,
+            String productId,
+            AdminProductDeliveryOptionsDto.Request dto
+    ) {
+        Validator.isAdmin(role);
+
+        validateDto(dto);
+
+        var product = productRepository.findById(productId)
+                .orElseThrow(() -> new ResourceNotFoundException("product", "id", productId));
+        if (product.getDeliveryOption() != null) {
+            throw new BadRequestException("이미 등록되어 있는 배송옵션이 존재합니다");
+        }
+
+        var deliveryOption = ProductDeliveryOption.of(dto.courierName(), dto.fee(), product);
+
+        return AdminProductDeliveryOptionsDto.Response.from(deliveryOption);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AdminProductDeliveryOptionsDto.Response getByProductId(
+            String role,
+            String productId
+    ) {
+        return null;
+    }
+
+    @Override
+    @Transactional
+    public AdminProductDeliveryOptionsDto.Response update(
+            String role,
+            String productId,
+            AdminProductDeliveryOptionsDto.Request dto
+    ) {
+        return null;
+    }
+
+    private void validateDto(AdminProductDeliveryOptionsDto.Request dto) {
+        if (Validator.areNullOrBlank(dto.courierName())
+                || dto.fee() == null || dto.fee() < 0) {
+            throw new BadRequestException("모든 파라미터를 올바르게 요청해주세요");
+        }
+    }
+}

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/ProductDeliveryOptionServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/ProductDeliveryOptionServiceImpl.java
@@ -41,11 +41,18 @@ public class ProductDeliveryOptionServiceImpl implements ProductDeliveryOptionSe
 
     @Override
     @Transactional(readOnly = true)
-    public AdminProductDeliveryOptionsDto.Response getByProductId(
+    public AdminProductDeliveryOptionsDto.Response getByProductIdForAdmin(
             String role,
             String productId
     ) {
-        return null;
+        Validator.isAdmin(role);
+
+        var product = productRepository.findById(productId)
+                .orElseThrow(() -> new ResourceNotFoundException("product", "id", productId));
+
+        return product.getDeliveryOption() != null ?
+                AdminProductDeliveryOptionsDto.Response.from(product.getDeliveryOption()) :
+                AdminProductDeliveryOptionsDto.Response.empty(productId);
     }
 
     @Override

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/ProductDeliveryOptionServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/ProductDeliveryOptionServiceImpl.java
@@ -62,7 +62,21 @@ public class ProductDeliveryOptionServiceImpl implements ProductDeliveryOptionSe
             String productId,
             AdminProductDeliveryOptionsDto.Request dto
     ) {
-        return null;
+        Validator.isAdmin(role);
+
+        validateDto(dto);
+
+        var product = productRepository.findById(productId)
+                .orElseThrow(() -> new ResourceNotFoundException("product", "id", productId));
+
+        var deliveryOption = product.getDeliveryOption();
+        if (deliveryOption == null) {
+            throw new ResourceNotFoundException("deliveryOption");
+        }
+
+        deliveryOption.update(dto.courierName(), dto.fee());
+
+        return AdminProductDeliveryOptionsDto.Response.from(deliveryOption);
     }
 
     private void validateDto(AdminProductDeliveryOptionsDto.Request dto) {

--- a/src/main/java/com/liberty52/product/service/controller/ProductInfoController.java
+++ b/src/main/java/com/liberty52/product/service/controller/ProductInfoController.java
@@ -101,4 +101,15 @@ public class ProductInfoController {
         Validator.isAdmin(role);
         return productDeliveryOptionService.create(role, productId, dto);
     }
+
+    @Operation(summary = "상품의 배송옵션 조회", description = "관리자가 상품의 배송옵션을 조회합니다.")
+    @GetMapping("/admin/products/{productId}/deliveryOptions")
+    @ResponseStatus(HttpStatus.OK)
+    public AdminProductDeliveryOptionsDto.Response getProductDeliveryOptionByProduct(
+            @RequestHeader("LB-Role") String role,
+            @PathVariable("productId") String productId
+    ) {
+        Validator.isAdmin(role);
+        return productDeliveryOptionService.getByProductIdForAdmin(role, productId);
+    }
 }

--- a/src/main/java/com/liberty52/product/service/controller/ProductInfoController.java
+++ b/src/main/java/com/liberty52/product/service/controller/ProductInfoController.java
@@ -112,4 +112,16 @@ public class ProductInfoController {
         Validator.isAdmin(role);
         return productDeliveryOptionService.getByProductIdForAdmin(role, productId);
     }
+
+    @Operation(summary = "상품의 배송옵션 수정", description = "관리자가 상품의 배송옵션을 수정합니다.")
+    @PutMapping("/admin/products/{productId}/deliveryOptions")
+    @ResponseStatus(HttpStatus.OK)
+    public AdminProductDeliveryOptionsDto.Response updateProductDeliveryOptions(
+            @RequestHeader("LB-Role") String role,
+            @PathVariable("productId") String productId,
+            @Validated @RequestBody AdminProductDeliveryOptionsDto.Request dto
+    ) {
+        Validator.isAdmin(role);
+        return productDeliveryOptionService.update(role, productId, dto);
+    }
 }

--- a/src/main/java/com/liberty52/product/service/controller/ProductInfoController.java
+++ b/src/main/java/com/liberty52/product/service/controller/ProductInfoController.java
@@ -1,9 +1,7 @@
 package com.liberty52.product.service.controller;
 
-import com.liberty52.product.service.applicationservice.ProductInfoRetrieveService;
-import com.liberty52.product.service.applicationservice.ProductIntroductionDeleteService;
-import com.liberty52.product.service.applicationservice.ProductIntroductionImgSaveService;
-import com.liberty52.product.service.applicationservice.ProductIntroductionUpsertService;
+import com.liberty52.product.global.util.Validator;
+import com.liberty52.product.service.applicationservice.*;
 import com.liberty52.product.service.controller.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -25,6 +23,7 @@ public class ProductInfoController {
     private final ProductIntroductionUpsertService productIntroductionUpsertService;
     private final ProductIntroductionDeleteService productIntroductionDeleteService;
     private final ProductIntroductionImgSaveService productIntroductionImgSaveService;
+    private final ProductDeliveryOptionService productDeliveryOptionService;
 
     @Operation(summary = "상품 목록 조회", description = "상품 목록을 조회합니다.")
     @GetMapping("/products")
@@ -89,5 +88,17 @@ public class ProductInfoController {
     public String saveProductIntroductionImageByAdmin(@RequestHeader("LB-Role") String role,
 		@RequestPart(value = "file") MultipartFile imageFile) {
 		return productIntroductionImgSaveService.saveProductIntroductionImageByAdmin(role,imageFile);
+    }
+
+    @Operation(summary = "상품의 배송옵션 추가", description = "관리자가 상품의 배송옵션을 추가합니다.")
+    @PostMapping("/admin/products/{productId}/deliveryOptions")
+    @ResponseStatus(HttpStatus.OK)
+    public AdminProductDeliveryOptionsDto.Response createProductDeliveryOptions(
+            @RequestHeader("LB-Role") String role,
+            @PathVariable("productId") String productId,
+            @Validated @RequestBody AdminProductDeliveryOptionsDto.Request dto
+    ) {
+        Validator.isAdmin(role);
+        return productDeliveryOptionService.create(role, productId, dto);
     }
 }

--- a/src/main/java/com/liberty52/product/service/controller/dto/AdminProductDeliveryOptionsDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/AdminProductDeliveryOptionsDto.java
@@ -30,5 +30,13 @@ public class AdminProductDeliveryOptionsDto {
                     .fee(entity.getFee())
                     .build();
         }
+
+        public static Response empty(String productId) {
+            return Response.builder()
+                    .productId(productId)
+                    .courierName(null)
+                    .fee(null)
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/liberty52/product/service/controller/dto/AdminProductDeliveryOptionsDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/AdminProductDeliveryOptionsDto.java
@@ -1,0 +1,34 @@
+package com.liberty52.product.service.controller.dto;
+
+import com.liberty52.product.service.entity.ProductDeliveryOption;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+public class AdminProductDeliveryOptionsDto {
+    @Builder
+    public record Request(
+            @NotNull(message = "택배사 이름을 입력해주세요")
+            @NotBlank(message = "택배사 이름을 입력해주세요")
+            String courierName,
+            @NotNull(message = "배송비를 입력해주세요")
+            @Min(value = 0, message = "배송비는 0 이상 입력 가능합니다")
+            Integer fee
+    ) {}
+
+    @Builder
+    public record Response(
+            String productId,
+            String courierName,
+            Integer fee
+    ) {
+        public static Response from(ProductDeliveryOption entity) {
+            return Response.builder()
+                    .productId(entity.getProduct().getId())
+                    .courierName(entity.getCourierName())
+                    .fee(entity.getFee())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/liberty52/product/service/entity/Product.java
+++ b/src/main/java/com/liberty52/product/service/entity/Product.java
@@ -37,6 +37,9 @@ public class Product {
     @Column(length = 10000)
     private String content = "";
 
+    @OneToOne(mappedBy = "product")
+    private ProductDeliveryOption deliveryOption;
+
     @Builder
     private Product(String name, ProductState productState, Long price, boolean isCustom, String pictureUrl) {
         this.name = name;
@@ -61,6 +64,11 @@ public class Product {
     public void addOption(ProductOption productOption) {
         this.productOptions.add(productOption);
     }
+
+    public void setDeliveryOption(ProductDeliveryOption deliveryOption) {
+        this.deliveryOption = deliveryOption;
+    }
+
     public static Product create(String name, ProductState state, Long price, boolean isCustom) {
         return builder().name(name)
                 .productState(state)

--- a/src/main/java/com/liberty52/product/service/entity/Product.java
+++ b/src/main/java/com/liberty52/product/service/entity/Product.java
@@ -37,7 +37,7 @@ public class Product {
     @Column(length = 10000)
     private String content = "";
 
-    @OneToOne(mappedBy = "product")
+    @OneToOne(cascade = CascadeType.ALL, mappedBy = "product")
     private ProductDeliveryOption deliveryOption;
 
     @Builder

--- a/src/main/java/com/liberty52/product/service/entity/ProductDeliveryOption.java
+++ b/src/main/java/com/liberty52/product/service/entity/ProductDeliveryOption.java
@@ -55,4 +55,9 @@ public class ProductDeliveryOption {
         this.product = product;
         this.product.setDeliveryOption(this);
     }
+
+    public void update(String courierName, Integer fee) {
+        this.courierName = courierName;
+        this.fee = fee;
+    }
 }

--- a/src/main/java/com/liberty52/product/service/entity/ProductDeliveryOption.java
+++ b/src/main/java/com/liberty52/product/service/entity/ProductDeliveryOption.java
@@ -1,0 +1,45 @@
+package com.liberty52.product.service.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+@Entity(name = "product_delivery_option")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductDeliveryOption {
+
+    @Id
+    private final String id = UUID.randomUUID().toString();
+
+    /** 택배사 이름 */
+    @Column(name = "courier_name", nullable = false)
+    private String courierName;
+
+    /** 배송비 */
+    @Column(name = "delivery_fee", nullable = false)
+    private Integer fee;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @OneToOne(orphanRemoval = true)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    public void associate(Product product) {
+        this.product = product;
+        this.product.setDeliveryOption(this);
+    }
+}

--- a/src/main/java/com/liberty52/product/service/entity/ProductDeliveryOption.java
+++ b/src/main/java/com/liberty52/product/service/entity/ProductDeliveryOption.java
@@ -38,6 +38,19 @@ public class ProductDeliveryOption {
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 
+    public static ProductDeliveryOption of(
+            String courierName,
+            Integer fee,
+            Product product
+    ) {
+        var instance = ProductDeliveryOption.builder()
+                .courierName(courierName)
+                .fee(fee)
+                .build();
+        instance.associate(product);
+        return instance;
+    }
+
     public void associate(Product product) {
         this.product = product;
         this.product.setDeliveryOption(this);

--- a/src/test/java/com/liberty52/product/service/applicationservice/impl/ProductDeliveryOptionServiceImplTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/impl/ProductDeliveryOptionServiceImplTest.java
@@ -1,0 +1,175 @@
+package com.liberty52.product.service.applicationservice.impl;
+
+import com.liberty52.product.global.exception.external.badrequest.BadRequestException;
+import com.liberty52.product.global.exception.external.forbidden.InvalidRoleException;
+import com.liberty52.product.global.exception.external.notfound.ResourceNotFoundException;
+import com.liberty52.product.service.controller.dto.AdminProductDeliveryOptionsDto;
+import com.liberty52.product.service.repository.ProductRepository;
+import com.liberty52.product.service.utils.MockFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ProductDeliveryOptionServiceImplTest {
+
+    @InjectMocks
+    private ProductDeliveryOptionServiceImpl service;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Nested
+    @DisplayName("상품 배송옵션 추가")
+    class Creation {
+        @Test
+        @DisplayName("관리자가 상품의 배송옵션을 추가한다")
+        void create() {
+            // given
+            var product = MockFactory.createProduct("");
+            given(productRepository.findById(anyString()))
+                    .willReturn(Optional.of(product));
+            var role = "ADMIN";
+            var productId = product.getId();
+            var dto = AdminProductDeliveryOptionsDto.Request.builder()
+                    .courierName("courier_name")
+                    .fee(100_000)
+                    .build();
+            // when
+            var result = service.create(role, productId, dto);
+            // then
+            assertNotNull(result);
+            assertEquals(productId, result.productId());
+            assertEquals(dto.courierName(), result.courierName());
+            assertEquals(dto.fee(), result.fee());
+        }
+
+        @Test
+        @DisplayName("일반 유저가 상품의 배송옵션을 추가할 수 없다")
+        void create_not_admin() {
+            // given
+            var role = "USER";
+            // when
+            // then
+            assertThrows(
+                    InvalidRoleException.class,
+                    () -> service.create(role, "id", null)
+            );
+        }
+
+        @Test
+        @DisplayName("관리자가 택배사 이름 없이 배송옵션을 추가할 수 없다")
+        void create_no_courierName() {
+            // given
+            var role = "ADMIN";
+            var productId = "id";
+            var dto = AdminProductDeliveryOptionsDto.Request.builder()
+                    .fee(100_000)
+                    .build();
+            // when
+            // then
+            var ex = assertThrows(
+                    BadRequestException.class,
+                    () -> service.create(role, productId, dto)
+            );
+            assertEquals("모든 파라미터를 올바르게 요청해주세요", ex.getErrorMessage());
+        }
+
+        @Test
+        @DisplayName("관리자가 배송비 없이 배송옵션을 추가할 수 없다")
+        void create_no_fee() {
+            // given
+            var role = "ADMIN";
+            var productId = "id";
+            var dto = AdminProductDeliveryOptionsDto.Request.builder()
+                    .courierName("courier_name")
+                    .build();
+            // when
+            // then
+            var ex = assertThrows(
+                    BadRequestException.class,
+                    () -> service.create(role, productId, dto)
+            );
+            assertEquals("모든 파라미터를 올바르게 요청해주세요", ex.getErrorMessage());
+        }
+
+        @Test
+        @DisplayName("관리자가 0 미만 배송비의 배송옵션을 추가할 수 없다")
+        void create_fee_is_under_zero() {
+            // given
+            var role = "ADMIN";
+            var productId = "id";
+            var dto = AdminProductDeliveryOptionsDto.Request.builder()
+                    .courierName("courier_name")
+                    .fee(-1)
+                    .build();
+            // when
+            // then
+            var ex = assertThrows(
+                    BadRequestException.class,
+                    () -> service.create(role, productId, dto)
+            );
+            assertEquals("모든 파라미터를 올바르게 요청해주세요", ex.getErrorMessage());
+        }
+
+        @Test
+        @DisplayName("관리자가 존재하지 않는 상품의 배송옵션을 추가할 수 없다")
+        void create_not_found_product() {
+            // given
+            var product = MockFactory.createProduct("");
+            given(productRepository.findById(anyString()))
+                    .willReturn(Optional.empty());
+            var role = "ADMIN";
+            var productId = product.getId();
+            var dto = AdminProductDeliveryOptionsDto.Request.builder()
+                    .courierName("courier_name")
+                    .fee(100_000)
+                    .build();
+            // when
+            // then
+            assertThrows(
+                    ResourceNotFoundException.class,
+                    () -> service.create(role, productId, dto)
+            );
+        }
+
+        @Test
+        @DisplayName("관리자가 이미 배송옵션이 존재한 상품에 배송옵션을 추가할 수 없다")
+        void create_exist_options() {
+            // given
+            var product = MockFactory.createProduct("");
+            MockFactory.createProductDeliveryOption(product);
+            given(productRepository.findById(anyString()))
+                    .willReturn(Optional.of(product));
+            var role = "ADMIN";
+            var productId = product.getId();
+            var dto = AdminProductDeliveryOptionsDto.Request.builder()
+                    .courierName("courier_name")
+                    .fee(100_000)
+                    .build();
+            // when
+            // then
+            var ex = assertThrows(
+                    BadRequestException.class,
+                    () -> service.create(role, productId, dto)
+            );
+            assertEquals("이미 등록되어 있는 배송옵션이 존재합니다", ex.getErrorMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("상품 배송옵션 조회")
+    class Retrieve {
+
+    }
+}

--- a/src/test/java/com/liberty52/product/service/controller/ProductInfoControllerTest.java
+++ b/src/test/java/com/liberty52/product/service/controller/ProductInfoControllerTest.java
@@ -1,0 +1,109 @@
+package com.liberty52.product.service.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.liberty52.product.service.applicationservice.*;
+import com.liberty52.product.service.controller.dto.AdminProductDeliveryOptionsDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ProductInfoController.class)
+class ProductInfoControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ProductInfoRetrieveService productInfoRetrieveService;
+
+    @MockBean
+    private ProductIntroductionUpsertService productIntroductionUpsertService;
+
+    @MockBean
+    private ProductIntroductionDeleteService productIntroductionDeleteService;
+
+    @MockBean
+    private ProductIntroductionImgSaveService productIntroductionImgSaveService;
+
+    @MockBean
+    private ProductDeliveryOptionService productDeliveryOptionService;
+
+    @Nested
+    @DisplayName("관리자 상품 배송옵션 API")
+    class API_ProductDeliveryOption {
+        @Nested
+        @DisplayName("배송옵션 추가")
+        class Creation {
+            @Test
+            @DisplayName("관리자가 상품의 배송옵션을 추가한다")
+            void createProductDeliveryOptions() throws Exception {
+                // given
+                var productId = "product-id";
+                var courierName = "courier_name";
+                var fee = 100_000;
+                var request = AdminProductDeliveryOptionsDto.Request.builder()
+                        .courierName(courierName)
+                        .fee(fee)
+                        .build();
+
+                given(productDeliveryOptionService.create(any(), any(), any()))
+                        .willReturn(AdminProductDeliveryOptionsDto.Response.builder()
+                                .productId(productId)
+                                .courierName(courierName)
+                                .fee(fee)
+                                .build());
+                // when
+                // then
+                mockMvc.perform(
+                        post("/admin/products/{productId}/deliveryOptions", productId)
+                                .header(HttpHeaders.AUTHORIZATION, "admin-id")
+                                .header("LB-Role", "ADMIN")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                ).andExpectAll(
+                        status().isOk(),
+                        jsonPath("$.productId").value(productId),
+                        jsonPath("$.courierName").value(courierName),
+                        jsonPath("$.fee").value(fee)
+                );
+            }
+
+            @Test
+            @DisplayName("일반 유저는 상품의 배송옵션을 추가할 수 없다")
+            void createProductDeliveryOptions_notAdmin() throws Exception {
+                // given
+                var productId = "product-id";
+                var courierName = "courier_name";
+                var fee = 100_000;
+                var request = AdminProductDeliveryOptionsDto.Request.builder()
+                        .courierName(courierName)
+                        .fee(fee)
+                        .build();
+                // when
+                // then
+                mockMvc.perform(
+                        post("/admin/products/{productId}/deliveryOptions", productId)
+                                .header(HttpHeaders.AUTHORIZATION, "user-id")
+                                .header("LB-Role", "USER")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                ).andExpect(status().isForbidden());
+            }
+        }
+    }
+}

--- a/src/test/java/com/liberty52/product/service/utils/MockFactory.java
+++ b/src/test/java/com/liberty52/product/service/utils/MockFactory.java
@@ -75,6 +75,21 @@ public class MockFactory {
         return createOptionDetail(name, price, true, stock, po);
     }
 
+    public static ProductDeliveryOption createProductDeliveryOption(Product product) {
+        return createProductDeliveryOption("courier_name", 100_000, product);
+    }
+
+    public static ProductDeliveryOption createProductDeliveryOption(String courierName, Integer fee, Product product) {
+        var pdo = ProductDeliveryOption.builder()
+                .courierName(courierName)
+                .fee(fee)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+        pdo.associate(product);
+        return pdo;
+    }
+
     public static CustomProductOption createProductCartOption() {
         return CustomProductOption.create();
     }


### PR DESCRIPTION
## 스프린트 넘버  : 6
## 메이저 마일스톤 : 관리자
### 마이너 마일스톤 : 상품관리 
### 백로그 이름 : [관리자] 한 상품당 택배사/배송비 추가 및 조회, [관리자] 한 상품당 택배사/배송비 수정

Resolve #328 

***
### 작업

상품별 택배사이름 및 배송비를 등록, 조회, 수정할 수 있는 기능을 추가하였습니다.

**API**
명세는 #328 을 참고해주세요. API 명세서 추가 예정입니다.


***
### 테스트 결과
<img width="265" alt="image" src="https://github.com/Liberty52/product/assets/42243302/1f7564f1-c91c-4bf8-8ac6-28f46d8b344c">
<br>
<img width="491" alt="image" src="https://github.com/Liberty52/product/assets/42243302/a1e9fc64-bb87-47fb-bc0a-2a8454a96fd9">
<br>
<img width="491" alt="image" src="https://github.com/Liberty52/product/assets/42243302/1860bd03-b693-4254-b3e8-b7cac4ef2d5d">


***
### 이슈
