### PR TITLE
[관리자] 라이선스 상품 옵션 CRUD

### DIFF
--- a/src/main/java/com/liberty52/product/service/applicationservice/LicenseOptionCreateService.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/LicenseOptionCreateService.java
@@ -1,0 +1,7 @@
+package com.liberty52.product.service.applicationservice;
+
+import com.liberty52.product.service.controller.dto.LicenseOptionCreateRequestDto;
+
+public interface LicenseOptionCreateService {
+    void createLicenseOptionByAdmin(String role, LicenseOptionCreateRequestDto dto, String productId);
+}

--- a/src/main/java/com/liberty52/product/service/applicationservice/LicenseOptionDetailCreateService.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/LicenseOptionDetailCreateService.java
@@ -1,7 +1,10 @@
 package com.liberty52.product.service.applicationservice;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import com.liberty52.product.service.controller.dto.LicenseOptionDetailCreateDto;
 
 public interface LicenseOptionDetailCreateService {
-    void createLicenseOptionDetailByAdmin(String role, LicenseOptionDetailCreateDto dto, String licenseOptionId);
+	void createLicenseOptionDetailByAdmin(String role, LicenseOptionDetailCreateDto dto, String licenseOptionId,
+		MultipartFile artImageFile);
 }

--- a/src/main/java/com/liberty52/product/service/applicationservice/LicenseOptionDetailCreateService.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/LicenseOptionDetailCreateService.java
@@ -1,0 +1,7 @@
+package com.liberty52.product.service.applicationservice;
+
+import com.liberty52.product.service.controller.dto.LicenseOptionDetailCreateDto;
+
+public interface LicenseOptionDetailCreateService {
+    void createLicenseOptionDetailByAdmin(String role, LicenseOptionDetailCreateDto dto, String licenseOptionId);
+}

--- a/src/main/java/com/liberty52/product/service/applicationservice/LicenseOptionDetailModifyService.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/LicenseOptionDetailModifyService.java
@@ -1,9 +1,12 @@
 package com.liberty52.product.service.applicationservice;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import com.liberty52.product.service.controller.dto.LicenseOptionDetailModifyDto;
 
 public interface LicenseOptionDetailModifyService {
-    void modifyLicenseOptionDetailByAdmin(String role, String licenseOptionDetailId, LicenseOptionDetailModifyDto dto);
+    void modifyLicenseOptionDetailByAdmin(String role, String licenseOptionDetailId, LicenseOptionDetailModifyDto dto,
+        MultipartFile artImageFile);
 
     void modifyLicenseOptionDetailOnSailStateByAdmin(String role, String licenseOptionDetailId);
 }

--- a/src/main/java/com/liberty52/product/service/applicationservice/LicenseOptionDetailModifyService.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/LicenseOptionDetailModifyService.java
@@ -1,0 +1,9 @@
+package com.liberty52.product.service.applicationservice;
+
+import com.liberty52.product.service.controller.dto.LicenseOptionDetailModifyDto;
+
+public interface LicenseOptionDetailModifyService {
+    void modifyLicenseOptionDetailByAdmin(String role, String licenseOptionDetailId, LicenseOptionDetailModifyDto dto);
+
+    void modifyLicenseOptionDetailOnSailStateByAdmin(String role, String licenseOptionDetailId);
+}

--- a/src/main/java/com/liberty52/product/service/applicationservice/LicenseOptionModifyService.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/LicenseOptionModifyService.java
@@ -1,0 +1,7 @@
+package com.liberty52.product.service.applicationservice;
+
+import com.liberty52.product.service.controller.dto.LicenseOptionModifyRequestDto;
+
+public interface LicenseOptionModifyService {
+    void modifyLicenseOptionByAdmin(String role, String licenseOptionId, LicenseOptionModifyRequestDto dto);
+}

--- a/src/main/java/com/liberty52/product/service/applicationservice/LicenseProductInfoRetrieveService.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/LicenseProductInfoRetrieveService.java
@@ -1,0 +1,9 @@
+package com.liberty52.product.service.applicationservice;
+
+import java.util.List;
+
+import com.liberty52.product.service.controller.dto.LicenseOptionInfoResponseDto;
+
+public interface LicenseProductInfoRetrieveService {
+    List<LicenseOptionInfoResponseDto> retrieveLicenseProductOptionInfoListByAdmin(String role, String productId, boolean onSale);
+}

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionCreateServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionCreateServiceImpl.java
@@ -1,0 +1,34 @@
+package com.liberty52.product.service.applicationservice.impl;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.liberty52.product.global.exception.external.notfound.ResourceNotFoundException;
+import com.liberty52.product.global.util.Validator;
+import com.liberty52.product.service.applicationservice.LicenseOptionCreateService;
+import com.liberty52.product.service.controller.dto.LicenseOptionCreateRequestDto;
+import com.liberty52.product.service.entity.Product;
+import com.liberty52.product.service.entity.license.LicenseOption;
+import com.liberty52.product.service.repository.LicenseOptionRepository;
+import com.liberty52.product.service.repository.ProductRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LicenseOptionCreateServiceImpl implements LicenseOptionCreateService {
+
+	private final ProductRepository productRepository;
+	private final LicenseOptionRepository licenseOptionRepository;
+
+	@Override
+	public void createLicenseOptionByAdmin(String role, LicenseOptionCreateRequestDto dto, String productId) {
+		Validator.isAdmin(role);
+		Product product = productRepository.findById(productId)
+			.orElseThrow(() -> new ResourceNotFoundException("productId", "id", productId));
+		LicenseOption licenseOption = LicenseOption.create(dto.getName());
+		licenseOption.associate(product);
+		licenseOptionRepository.save(licenseOption);
+	}
+}

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionCreateServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionCreateServiceImpl.java
@@ -27,7 +27,7 @@ public class LicenseOptionCreateServiceImpl implements LicenseOptionCreateServic
 		Validator.isAdmin(role);
 		Product product = productRepository.findById(productId)
 			.orElseThrow(() -> new ResourceNotFoundException("productId", "id", productId));
-		LicenseOption licenseOption = LicenseOption.create(dto.getName());
+		LicenseOption licenseOption = LicenseOption.create(dto.getName(), dto.getRequire(), dto.getOnSale());
 		licenseOption.associate(product);
 		licenseOptionRepository.save(licenseOption);
 	}

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionDetailCreateServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionDetailCreateServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.liberty52.product.global.adapter.s3.S3UploaderApi;
+import com.liberty52.product.global.exception.external.badrequest.BadRequestException;
 import com.liberty52.product.global.exception.external.notfound.ResourceNotFoundException;
 import com.liberty52.product.global.util.Validator;
 import com.liberty52.product.service.applicationservice.LicenseOptionDetailCreateService;
@@ -30,6 +31,9 @@ public class LicenseOptionDetailCreateServiceImpl implements LicenseOptionDetail
 		Validator.isAdmin(role);
 		LicenseOption licenseOption = licenseOptionRepository.findById(licenseOptionId)
 			.orElseThrow(() -> new ResourceNotFoundException("option", "id", licenseOptionId));
+		if (artImageFile == null) {
+			throw new BadRequestException("ArtImageFile must be not null");
+		}
 		LicenseOptionDetail licenseOptionDetail = LicenseOptionDetail.create(dto.getArtName(), dto.getArtistName(),
 			dto.getStock(), dto.getOnSale(), s3Uploader.upload(artImageFile));
 		licenseOptionDetail.associate(licenseOption);

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionDetailCreateServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionDetailCreateServiceImpl.java
@@ -2,21 +2,17 @@ package com.liberty52.product.service.applicationservice.impl;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import com.liberty52.product.global.adapter.s3.S3UploaderApi;
 import com.liberty52.product.global.exception.external.notfound.ResourceNotFoundException;
 import com.liberty52.product.global.util.Validator;
 import com.liberty52.product.service.applicationservice.LicenseOptionDetailCreateService;
-import com.liberty52.product.service.applicationservice.OptionDetailCreateService;
-import com.liberty52.product.service.controller.dto.CreateOptionDetailRequestDto;
 import com.liberty52.product.service.controller.dto.LicenseOptionDetailCreateDto;
-import com.liberty52.product.service.entity.OptionDetail;
-import com.liberty52.product.service.entity.ProductOption;
 import com.liberty52.product.service.entity.license.LicenseOption;
 import com.liberty52.product.service.entity.license.LicenseOptionDetail;
 import com.liberty52.product.service.repository.LicenseOptionDetailRepository;
 import com.liberty52.product.service.repository.LicenseOptionRepository;
-import com.liberty52.product.service.repository.OptionDetailRepository;
-import com.liberty52.product.service.repository.ProductOptionRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,14 +22,16 @@ import lombok.RequiredArgsConstructor;
 public class LicenseOptionDetailCreateServiceImpl implements LicenseOptionDetailCreateService {
 	private final LicenseOptionRepository licenseOptionRepository;
 	private final LicenseOptionDetailRepository licenseOptionDetailRepository;
+	private final S3UploaderApi s3Uploader;
 
 	@Override
-	public void createLicenseOptionDetailByAdmin(String role, LicenseOptionDetailCreateDto dto, String licenseOptionId) {
+	public void createLicenseOptionDetailByAdmin(String role, LicenseOptionDetailCreateDto dto, String licenseOptionId,
+		MultipartFile artImageFile) {
 		Validator.isAdmin(role);
 		LicenseOption licenseOption = licenseOptionRepository.findById(licenseOptionId)
 			.orElseThrow(() -> new ResourceNotFoundException("option", "id", licenseOptionId));
 		LicenseOptionDetail licenseOptionDetail = LicenseOptionDetail.create(dto.getArtName(), dto.getArtistName(),
-			dto.getStock(), dto.getOnSale(), dto.getArtUrl());
+			dto.getStock(), dto.getOnSale(), s3Uploader.upload(artImageFile));
 		licenseOptionDetail.associate(licenseOption);
 		licenseOptionDetailRepository.save(licenseOptionDetail);
 	}

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionDetailCreateServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionDetailCreateServiceImpl.java
@@ -1,0 +1,40 @@
+package com.liberty52.product.service.applicationservice.impl;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.liberty52.product.global.exception.external.notfound.ResourceNotFoundException;
+import com.liberty52.product.global.util.Validator;
+import com.liberty52.product.service.applicationservice.LicenseOptionDetailCreateService;
+import com.liberty52.product.service.applicationservice.OptionDetailCreateService;
+import com.liberty52.product.service.controller.dto.CreateOptionDetailRequestDto;
+import com.liberty52.product.service.controller.dto.LicenseOptionDetailCreateDto;
+import com.liberty52.product.service.entity.OptionDetail;
+import com.liberty52.product.service.entity.ProductOption;
+import com.liberty52.product.service.entity.license.LicenseOption;
+import com.liberty52.product.service.entity.license.LicenseOptionDetail;
+import com.liberty52.product.service.repository.LicenseOptionDetailRepository;
+import com.liberty52.product.service.repository.LicenseOptionRepository;
+import com.liberty52.product.service.repository.OptionDetailRepository;
+import com.liberty52.product.service.repository.ProductOptionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LicenseOptionDetailCreateServiceImpl implements LicenseOptionDetailCreateService {
+	private final LicenseOptionRepository licenseOptionRepository;
+	private final LicenseOptionDetailRepository licenseOptionDetailRepository;
+
+	@Override
+	public void createLicenseOptionDetailByAdmin(String role, LicenseOptionDetailCreateDto dto, String licenseOptionId) {
+		Validator.isAdmin(role);
+		LicenseOption licenseOption = licenseOptionRepository.findById(licenseOptionId)
+			.orElseThrow(() -> new ResourceNotFoundException("option", "id", licenseOptionId));
+		LicenseOptionDetail licenseOptionDetail = LicenseOptionDetail.create(dto.getArtName(), dto.getArtistName(),
+			dto.getStock(), dto.getOnSale(), dto.getArtUrl());
+		licenseOptionDetail.associate(licenseOption);
+		licenseOptionDetailRepository.save(licenseOptionDetail);
+	}
+}

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionDetailModifyServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionDetailModifyServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.liberty52.product.global.adapter.s3.S3UploaderApi;
+import com.liberty52.product.global.exception.external.badrequest.BadRequestException;
 import com.liberty52.product.global.exception.external.notfound.ResourceNotFoundException;
 import com.liberty52.product.global.util.Validator;
 import com.liberty52.product.service.applicationservice.LicenseOptionDetailModifyService;
@@ -27,6 +28,9 @@ public class LicenseOptionDetailModifyServiceImpl implements LicenseOptionDetail
 		Validator.isAdmin(role);
 		LicenseOptionDetail licenseOptionDetail = licenseOptionDetailRepository.findById(licenseOptionDetailId)
 			.orElseThrow(() -> new ResourceNotFoundException("OptionDetail", "ID", licenseOptionDetailId));
+		if (artImageFile == null) {
+			throw new BadRequestException("ArtImageFile must be not null");
+		}
 		licenseOptionDetail.modifyLicenseOptionDetail(dto, s3Uploader.upload(artImageFile));
 	}
 

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionDetailModifyServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionDetailModifyServiceImpl.java
@@ -2,7 +2,9 @@ package com.liberty52.product.service.applicationservice.impl;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import com.liberty52.product.global.adapter.s3.S3UploaderApi;
 import com.liberty52.product.global.exception.external.notfound.ResourceNotFoundException;
 import com.liberty52.product.global.util.Validator;
 import com.liberty52.product.service.applicationservice.LicenseOptionDetailModifyService;
@@ -17,14 +19,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class LicenseOptionDetailModifyServiceImpl implements LicenseOptionDetailModifyService {
 	private final LicenseOptionDetailRepository licenseOptionDetailRepository;
+	private final S3UploaderApi s3Uploader;
 
 	@Override
 	public void modifyLicenseOptionDetailByAdmin(String role, String licenseOptionDetailId,
-		LicenseOptionDetailModifyDto dto) {
+		LicenseOptionDetailModifyDto dto, MultipartFile artImageFile) {
 		Validator.isAdmin(role);
 		LicenseOptionDetail licenseOptionDetail = licenseOptionDetailRepository.findById(licenseOptionDetailId)
 			.orElseThrow(() -> new ResourceNotFoundException("OptionDetail", "ID", licenseOptionDetailId));
-		licenseOptionDetail.modifyLicenseOptionDetail(dto);
+		licenseOptionDetail.modifyLicenseOptionDetail(dto, s3Uploader.upload(artImageFile));
 	}
 
 	@Override

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionDetailModifyServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionDetailModifyServiceImpl.java
@@ -1,0 +1,37 @@
+package com.liberty52.product.service.applicationservice.impl;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.liberty52.product.global.exception.external.notfound.ResourceNotFoundException;
+import com.liberty52.product.global.util.Validator;
+import com.liberty52.product.service.applicationservice.LicenseOptionDetailModifyService;
+import com.liberty52.product.service.controller.dto.LicenseOptionDetailModifyDto;
+import com.liberty52.product.service.entity.license.LicenseOptionDetail;
+import com.liberty52.product.service.repository.LicenseOptionDetailRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class LicenseOptionDetailModifyServiceImpl implements LicenseOptionDetailModifyService {
+	private final LicenseOptionDetailRepository licenseOptionDetailRepository;
+
+	@Override
+	public void modifyLicenseOptionDetailByAdmin(String role, String licenseOptionDetailId,
+		LicenseOptionDetailModifyDto dto) {
+		Validator.isAdmin(role);
+		LicenseOptionDetail licenseOptionDetail = licenseOptionDetailRepository.findById(licenseOptionDetailId)
+			.orElseThrow(() -> new ResourceNotFoundException("OptionDetail", "ID", licenseOptionDetailId));
+		licenseOptionDetail.modifyLicenseOptionDetail(dto);
+	}
+
+	@Override
+	public void modifyLicenseOptionDetailOnSailStateByAdmin(String role, String licenseOptionDetailId) {
+		Validator.isAdmin(role);
+		LicenseOptionDetail licenseOptionDetail = licenseOptionDetailRepository.findById(licenseOptionDetailId)
+			.orElseThrow(() -> new ResourceNotFoundException("OptionDetail", "ID", licenseOptionDetailId));
+		licenseOptionDetail.updateOnSale();
+	}
+}

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionModifyServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionModifyServiceImpl.java
@@ -24,6 +24,6 @@ public class LicenseOptionModifyServiceImpl implements LicenseOptionModifyServic
 		Validator.isAdmin(role);
 		LicenseOption licenseOption = licenseOptionRepository.findById(licenseOptionId)
 			.orElseThrow(() -> new ResourceNotFoundException("ProductOption", "ID", licenseOptionId));
-		licenseOption.modifyLicenseOption(dto.getName());
+		licenseOption.modifyLicenseOption(dto.getName(), dto.getRequire(), dto.getOnSale());
 	}
 }

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionModifyServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionModifyServiceImpl.java
@@ -1,0 +1,29 @@
+package com.liberty52.product.service.applicationservice.impl;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.liberty52.product.global.exception.external.notfound.ResourceNotFoundException;
+import com.liberty52.product.global.util.Validator;
+import com.liberty52.product.service.applicationservice.LicenseOptionModifyService;
+import com.liberty52.product.service.controller.dto.LicenseOptionModifyRequestDto;
+import com.liberty52.product.service.entity.license.LicenseOption;
+import com.liberty52.product.service.repository.LicenseOptionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class LicenseOptionModifyServiceImpl implements LicenseOptionModifyService {
+
+	private final LicenseOptionRepository licenseOptionRepository;
+
+	@Override
+	public void modifyLicenseOptionByAdmin(String role, String licenseOptionId, LicenseOptionModifyRequestDto dto) {
+		Validator.isAdmin(role);
+		LicenseOption licenseOption = licenseOptionRepository.findById(licenseOptionId)
+			.orElseThrow(() -> new ResourceNotFoundException("ProductOption", "ID", licenseOptionId));
+		licenseOption.modifyLicenseOption(dto.getName());
+	}
+}

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseProductInfoRetrieveServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseProductInfoRetrieveServiceImpl.java
@@ -3,7 +3,6 @@ package com.liberty52.product.service.applicationservice.impl;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseProductInfoRetrieveServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseProductInfoRetrieveServiceImpl.java
@@ -1,0 +1,49 @@
+package com.liberty52.product.service.applicationservice.impl;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.liberty52.product.global.exception.external.notfound.ResourceNotFoundException;
+import com.liberty52.product.global.util.Validator;
+import com.liberty52.product.service.applicationservice.LicenseProductInfoRetrieveService;
+import com.liberty52.product.service.controller.dto.LicenseOptionInfoResponseDto;
+import com.liberty52.product.service.entity.Product;
+import com.liberty52.product.service.entity.license.LicenseOption;
+import com.liberty52.product.service.repository.ProductRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class LicenseProductInfoRetrieveServiceImpl implements LicenseProductInfoRetrieveService {
+	private final ProductRepository productRepository;
+
+	@Override
+	public List<LicenseOptionInfoResponseDto> retrieveLicenseProductOptionInfoListByAdmin(String role,
+		String productId, boolean onSale) {
+		Validator.isAdmin(role);
+		Product product = productRepository.findById(productId)
+			.orElseThrow(() -> new ResourceNotFoundException("product", "id", productId));
+		if (product.getLicenseOptions().isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		if (onSale) {
+			return product.getLicenseOptions()
+				.stream()
+				.filter(LicenseOption::getOnSale)
+				.map(licenseOption -> new LicenseOptionInfoResponseDto(licenseOption, true))
+				.toList();
+		} else {
+			return product.getLicenseOptions()
+				.stream()
+				.sorted(Comparator.comparing(LicenseOption::getOnSale).reversed())
+				.map(licenseOption -> new LicenseOptionInfoResponseDto(licenseOption, false))
+				.toList();
+		}
+	}
+}

--- a/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionCreateRequestDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionCreateRequestDto.java
@@ -1,0 +1,19 @@
+package com.liberty52.product.service.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class LicenseOptionCreateRequestDto {
+
+    @NotBlank
+    String name;
+
+    public static LicenseOptionCreateRequestDto create(String name){
+        return new LicenseOptionCreateRequestDto(name);
+    }
+}

--- a/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionCreateRequestDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionCreateRequestDto.java
@@ -1,6 +1,7 @@
 package com.liberty52.product.service.controller.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,8 +13,12 @@ public class LicenseOptionCreateRequestDto {
 
     @NotBlank
     String name;
+    @NotNull
+    Boolean require;
+    @NotNull
+    Boolean onSale;
 
-    public static LicenseOptionCreateRequestDto create(String name){
-        return new LicenseOptionCreateRequestDto(name);
+    public static LicenseOptionCreateRequestDto create(String name, Boolean require, Boolean onSale){
+        return new LicenseOptionCreateRequestDto(name, require, onSale);
     }
 }

--- a/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionDetailCreateDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionDetailCreateDto.java
@@ -17,17 +17,13 @@ public class LicenseOptionDetailCreateDto {
 	Integer stock;
 	@NotNull
 	Boolean onSale;
-	@NotBlank
-	String artUrl;
 
-	public static LicenseOptionDetailCreateDto create(String artName, String artistName, Integer stock, Boolean onSale,
-		String artUrl) {
+	public static LicenseOptionDetailCreateDto create(String artName, String artistName, Integer stock, Boolean onSale) {
 		LicenseOptionDetailCreateDto dto = new LicenseOptionDetailCreateDto();
 		dto.artName = artName;
 		dto.artistName = artistName;
 		dto.stock = stock;
 		dto.onSale = onSale;
-		dto.artUrl = artUrl;
 		return dto;
 	}
 

--- a/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionDetailCreateDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionDetailCreateDto.java
@@ -1,0 +1,34 @@
+package com.liberty52.product.service.controller.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class LicenseOptionDetailCreateDto {
+
+	@NotBlank
+	String artName;
+	@NotBlank
+	String artistName;
+	@NotNull
+	@Min(0)
+	Integer stock;
+	@NotNull
+	Boolean onSale;
+	@NotBlank
+	String artUrl;
+
+	public static LicenseOptionDetailCreateDto create(String artName, String artistName, Integer stock, Boolean onSale,
+		String artUrl) {
+		LicenseOptionDetailCreateDto dto = new LicenseOptionDetailCreateDto();
+		dto.artName = artName;
+		dto.artistName = artistName;
+		dto.stock = stock;
+		dto.onSale = onSale;
+		dto.artUrl = artUrl;
+		return dto;
+	}
+
+}

--- a/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionDetailInfoResponseDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionDetailInfoResponseDto.java
@@ -1,0 +1,30 @@
+package com.liberty52.product.service.controller.dto;
+
+import com.liberty52.product.service.entity.license.LicenseOptionDetail;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LicenseOptionDetailInfoResponseDto {
+
+	String licenseOptionDetailId;
+	String artName;
+	String artistName;
+	Integer stock;
+	Boolean onSale;
+	String artUrl;
+
+	public LicenseOptionDetailInfoResponseDto(LicenseOptionDetail licenseOptionDetail) {
+		licenseOptionDetailId = licenseOptionDetail.getId();
+		artName = licenseOptionDetail.getArtName();
+		artistName = licenseOptionDetail.getArtistName();
+		stock = licenseOptionDetail.getStock();
+		onSale = licenseOptionDetail.getOnSale();
+		artUrl = licenseOptionDetail.getArtUrl();
+	}
+
+}

--- a/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionDetailModifyDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionDetailModifyDto.java
@@ -20,17 +20,13 @@ public class LicenseOptionDetailModifyDto {
 	Integer stock;
 	@NotNull
 	Boolean onSale;
-	@NotBlank
-	String artUrl;
 
-	public static LicenseOptionDetailModifyDto create(String artName, String artistName, Integer stock, Boolean onSale,
-		String artUrl) {
+	public static LicenseOptionDetailModifyDto create(String artName, String artistName, Integer stock, Boolean onSale) {
 		LicenseOptionDetailModifyDto dto = new LicenseOptionDetailModifyDto();
 		dto.artName = artName;
 		dto.artistName = artistName;
 		dto.stock = stock;
 		dto.onSale = onSale;
-		dto.artUrl = artUrl;
 		return dto;
 	}
 

--- a/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionDetailModifyDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionDetailModifyDto.java
@@ -1,0 +1,37 @@
+package com.liberty52.product.service.controller.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LicenseOptionDetailModifyDto {
+	@NotBlank
+	String artName;
+	@NotBlank
+	String artistName;
+	@NotNull
+	@Min(0)
+	Integer stock;
+	@NotNull
+	Boolean onSale;
+	@NotBlank
+	String artUrl;
+
+	public static LicenseOptionDetailModifyDto create(String artName, String artistName, Integer stock, Boolean onSale,
+		String artUrl) {
+		LicenseOptionDetailModifyDto dto = new LicenseOptionDetailModifyDto();
+		dto.artName = artName;
+		dto.artistName = artistName;
+		dto.stock = stock;
+		dto.onSale = onSale;
+		dto.artUrl = artUrl;
+		return dto;
+	}
+
+}

--- a/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionInfoResponseDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionInfoResponseDto.java
@@ -3,7 +3,6 @@ package com.liberty52.product.service.controller.dto;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.liberty52.product.service.entity.license.LicenseOption;
 import com.liberty52.product.service.entity.license.LicenseOptionDetail;

--- a/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionInfoResponseDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionInfoResponseDto.java
@@ -1,0 +1,52 @@
+package com.liberty52.product.service.controller.dto;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.liberty52.product.service.entity.license.LicenseOption;
+import com.liberty52.product.service.entity.license.LicenseOptionDetail;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LicenseOptionInfoResponseDto {
+
+	String licenseOptionId;
+	String optionName;
+	Boolean onSale;
+	Boolean require;
+	List<LicenseOptionDetailInfoResponseDto> licenseOptionDetailList;
+
+	public LicenseOptionInfoResponseDto(LicenseOption licenseOption, boolean onSale) {
+		this.licenseOptionId = licenseOption.getId();
+		this.optionName = licenseOption.getName();
+		this.require = licenseOption.getRequire();
+		this.onSale = licenseOption.getOnSale();
+
+		if (licenseOption.getLicenseOptionDetails().isEmpty()) {
+			licenseOptionDetailList = Collections.emptyList();
+		}
+
+		if (onSale) {
+			licenseOptionDetailList = licenseOption.getLicenseOptionDetails()
+				.stream()
+				.filter(LicenseOptionDetail::getOnSale)
+				.map(LicenseOptionDetailInfoResponseDto::new)
+				.toList();
+
+		} else {
+			licenseOptionDetailList = licenseOption.getLicenseOptionDetails()
+				.stream()
+				.sorted(Comparator.comparing(LicenseOptionDetail::getOnSale).reversed())
+				.map(LicenseOptionDetailInfoResponseDto::new)
+				.toList();
+		}
+	}
+
+}

--- a/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionModifyRequestDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionModifyRequestDto.java
@@ -1,0 +1,20 @@
+package com.liberty52.product.service.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LicenseOptionModifyRequestDto {
+
+    @NotBlank
+    String name;
+
+    public static LicenseOptionModifyRequestDto create(String name){
+        return new LicenseOptionModifyRequestDto(name);
+    }
+}

--- a/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionModifyRequestDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionModifyRequestDto.java
@@ -11,10 +11,14 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class LicenseOptionModifyRequestDto {
 
-    @NotBlank
-    String name;
+	@NotBlank
+	String name;
+	@NotNull
+	Boolean require;
+	@NotNull
+	Boolean onSale;
 
-    public static LicenseOptionModifyRequestDto create(String name){
-        return new LicenseOptionModifyRequestDto(name);
-    }
+	public static LicenseOptionModifyRequestDto create(String name, Boolean require, Boolean onSale) {
+		return new LicenseOptionModifyRequestDto(name, require, onSale);
+	}
 }

--- a/src/main/java/com/liberty52/product/service/controller/license/LicenseOptionController.java
+++ b/src/main/java/com/liberty52/product/service/controller/license/LicenseOptionController.java
@@ -1,0 +1,44 @@
+package com.liberty52.product.service.controller.license;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.liberty52.product.service.applicationservice.LicenseOptionCreateService;
+import com.liberty52.product.service.applicationservice.LicenseOptionModifyService;
+import com.liberty52.product.service.controller.dto.LicenseOptionCreateRequestDto;
+import com.liberty52.product.service.controller.dto.LicenseOptionModifyRequestDto;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "라이선스 상품", description = "라이선스 상품 관련 API를 제공합니다")
+@RestController
+@RequiredArgsConstructor
+public class LicenseOptionController {
+	private final LicenseOptionCreateService licenseOptionCreateService;
+	private final LicenseOptionModifyService licenseOptionModifyService;
+
+	@Operation(summary = "라이선스 상품 옵션 생성", description = "관리자가 특정 라이선스 상품에 옵션을 생성합니다.")
+	@PostMapping("/admin/licenseOption/{productId}")
+	@ResponseStatus(HttpStatus.CREATED)
+	public void createLicenseOptionByAdmin(@RequestHeader("LB-Role") String role,
+		@Validated @RequestBody LicenseOptionCreateRequestDto dto, @PathVariable String productId) {
+		licenseOptionCreateService.createLicenseOptionByAdmin(role, dto, productId);
+	}
+
+	@Operation(summary = "라이선스 상품 옵션 수정", description = "관리자가 특정 라이선스 상품 옵션을 수정합니다.")
+	@PutMapping("/admin/licenseOption/{licenseOptionId}")
+	@ResponseStatus(HttpStatus.OK)
+	public void modifyLicenseOptionByAdmin(@RequestHeader("LB-Role") String role, @PathVariable String licenseOptionId,
+		@Validated @RequestBody LicenseOptionModifyRequestDto dto) {
+		licenseOptionModifyService.modifyLicenseOptionByAdmin(role, licenseOptionId, dto);
+	}
+}

--- a/src/main/java/com/liberty52/product/service/controller/license/LicenseOptionDetailController.java
+++ b/src/main/java/com/liberty52/product/service/controller/license/LicenseOptionDetailController.java
@@ -7,8 +7,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.liberty52.product.service.applicationservice.LicenseOptionDetailCreateService;
 import com.liberty52.product.service.applicationservice.LicenseOptionDetailModifyService;
@@ -33,8 +35,9 @@ public class LicenseOptionDetailController {
 	@PostMapping("/admin/licenseOptionDetail/{licenseOptionId}")
 	@ResponseStatus(HttpStatus.CREATED)
 	public void createLicenseOptionDetailByAdmin(@RequestHeader("LB-Role") String role,
-		@Validated @RequestBody LicenseOptionDetailCreateDto dto, @PathVariable String licenseOptionId) {
-		licenseOptionDetailCreateService.createLicenseOptionDetailByAdmin(role, dto, licenseOptionId);
+		@Validated @RequestBody LicenseOptionDetailCreateDto dto, @PathVariable String licenseOptionId,
+		@RequestPart(value = "file") MultipartFile imageFile) {
+		licenseOptionDetailCreateService.createLicenseOptionDetailByAdmin(role, dto, licenseOptionId, imageFile);
 	}
 
 	@Operation(summary = "라이선스 옵션 상세 수정", description = "관리자가 라이선스 옵션 상세 정보를 수정합니다.")
@@ -43,9 +46,10 @@ public class LicenseOptionDetailController {
 	public void modifyLicenseOptionDetailByAdmin(
 		@RequestHeader("LB-Role") String role,
 		@PathVariable String licenseOptionDetailId,
-		@Validated @RequestBody LicenseOptionDetailModifyDto dto
+		@Validated @RequestBody LicenseOptionDetailModifyDto dto,
+		@RequestPart(value = "file") MultipartFile imageFile
 	) {
-		licenseOptionDetailModifyService.modifyLicenseOptionDetailByAdmin(role, licenseOptionDetailId, dto);
+		licenseOptionDetailModifyService.modifyLicenseOptionDetailByAdmin(role, licenseOptionDetailId, dto, imageFile);
 	}
 
 	@Operation(summary = "라이선스 옵션 상세 판매 상태 수정", description = "관리자가 라이선스 옵션 상세의 판매 상태를 수정합니다.")

--- a/src/main/java/com/liberty52/product/service/controller/license/LicenseOptionDetailController.java
+++ b/src/main/java/com/liberty52/product/service/controller/license/LicenseOptionDetailController.java
@@ -1,0 +1,60 @@
+package com.liberty52.product.service.controller.license;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.liberty52.product.service.applicationservice.LicenseOptionDetailCreateService;
+import com.liberty52.product.service.applicationservice.LicenseOptionDetailModifyService;
+import com.liberty52.product.service.applicationservice.OptionDetailModifyService;
+import com.liberty52.product.service.controller.dto.LicenseOptionDetailCreateDto;
+import com.liberty52.product.service.controller.dto.LicenseOptionDetailModifyDto;
+import com.liberty52.product.service.controller.dto.OptionDetailModifyRequestDto;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "라이선스 상품", description = "라이선스 상품 관련 API를 제공합니다")
+@RestController
+@RequiredArgsConstructor
+public class LicenseOptionDetailController {
+
+	private final LicenseOptionDetailCreateService licenseOptionDetailCreateService;
+	private final LicenseOptionDetailModifyService licenseOptionDetailModifyService;
+
+	@Operation(summary = "라이선스 옵션 상세 생성", description = "관리자가 새로운 라이선스 옵션 상세를 생성합니다.")
+	@PostMapping("/admin/licenseOptionDetail/{licenseOptionId}")
+	@ResponseStatus(HttpStatus.CREATED)
+	public void createLicenseOptionDetailByAdmin(@RequestHeader("LB-Role") String role,
+		@Validated @RequestBody LicenseOptionDetailCreateDto dto, @PathVariable String licenseOptionId) {
+		licenseOptionDetailCreateService.createLicenseOptionDetailByAdmin(role, dto, licenseOptionId);
+	}
+
+	@Operation(summary = "라이선스 옵션 상세 수정", description = "관리자가 라이선스 옵션 상세 정보를 수정합니다.")
+	@PutMapping("/admin/licenseOptionDetail/{licenseOptionDetailId}")
+	@ResponseStatus(HttpStatus.OK)
+	public void modifyLicenseOptionDetailByAdmin(
+		@RequestHeader("LB-Role") String role,
+		@PathVariable String licenseOptionDetailId,
+		@Validated @RequestBody LicenseOptionDetailModifyDto dto
+	) {
+		licenseOptionDetailModifyService.modifyLicenseOptionDetailByAdmin(role, licenseOptionDetailId, dto);
+	}
+
+	@Operation(summary = "라이선스 옵션 상세 판매 상태 수정", description = "관리자가 라이선스 옵션 상세의 판매 상태를 수정합니다.")
+	@PutMapping("/admin/licenseOptionDetailOnSale/{licenseOptionDetailId}")
+	@ResponseStatus(HttpStatus.OK)
+	public void modifyLicenseOptionDetailOnSailStateByAdmin(
+		@RequestHeader("LB-Role") String role,
+		@PathVariable String licenseOptionDetailId
+	) {
+		licenseOptionDetailModifyService.modifyLicenseOptionDetailOnSailStateByAdmin(role, licenseOptionDetailId);
+	}
+}

--- a/src/main/java/com/liberty52/product/service/controller/license/LicenseProductInfoController.java
+++ b/src/main/java/com/liberty52/product/service/controller/license/LicenseProductInfoController.java
@@ -1,0 +1,31 @@
+package com.liberty52.product.service.controller.license;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.liberty52.product.service.applicationservice.LicenseProductInfoRetrieveService;
+import com.liberty52.product.service.controller.dto.LicenseOptionInfoResponseDto;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "라이선스 상품 정보", description = "라이선스 상품 정보 관련 API를 제공합니다")
+@RestController
+@RequiredArgsConstructor
+public class LicenseProductInfoController {
+	private final LicenseProductInfoRetrieveService licenseProductInfoRetrieveService;
+	@Operation(summary = "관리자용 라이선스 상품 옵션 정보 조회", description = "관리자가 특정 라이선스 상품의 옵션 정보를 조회합니다.")
+	@GetMapping("/admin/licenseProductOptionInfo/{productId}")
+	@ResponseStatus(HttpStatus.OK)
+	public List<LicenseOptionInfoResponseDto> retrieveLicenseProductOptionInfoListByAdmin(@RequestHeader("LB-Role") String role, @PathVariable String productId, @RequestParam boolean onSale) {
+		return licenseProductInfoRetrieveService.retrieveLicenseProductOptionInfoListByAdmin(role, productId, onSale);
+	}
+}

--- a/src/main/java/com/liberty52/product/service/entity/Product.java
+++ b/src/main/java/com/liberty52/product/service/entity/Product.java
@@ -10,6 +10,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import com.liberty52.product.service.entity.license.LicenseOption;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -32,6 +34,8 @@ public class Product {
 
     @OneToMany(mappedBy = "product")
     private List<ProductOption> productOptions = new ArrayList<>();
+    @OneToMany(mappedBy = "product")
+    private List<LicenseOption> licenseOptions = new ArrayList<>();
 
     private String pictureUrl;
     @Column(length = 10000)
@@ -63,6 +67,10 @@ public class Product {
 
     public void addOption(ProductOption productOption) {
         this.productOptions.add(productOption);
+    }
+
+    public void addLicenseOptions(LicenseOption licenseOption) {
+        this.licenseOptions.add(licenseOption);
     }
 
     public void setDeliveryOption(ProductDeliveryOption deliveryOption) {

--- a/src/main/java/com/liberty52/product/service/entity/license/LicenseOption.java
+++ b/src/main/java/com/liberty52/product/service/entity/license/LicenseOption.java
@@ -1,0 +1,46 @@
+package com.liberty52.product.service.entity.license;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.liberty52.product.service.entity.Product;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "license_option")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LicenseOption {
+	@Id
+	private String id = UUID.randomUUID().toString();
+	@ManyToOne
+	@JoinColumn(name = "product_id")
+	private Product product;
+
+	@OneToMany(mappedBy = "licenseOption")
+	private List<LicenseOptionDetail> licenseOptionDetails;
+	@Column(nullable = false)
+	private String name;
+
+	public void associate(Product product) {
+		this.product = product;
+		this.product.addLicenseOptions(this);
+	}
+
+	public LicenseOption(String name) {
+		this.name = name;
+	}
+	public void addDetail(LicenseOptionDetail licenseOptionDetail) {
+		this.licenseOptionDetails.add(licenseOptionDetail);
+	}
+}

--- a/src/main/java/com/liberty52/product/service/entity/license/LicenseOption.java
+++ b/src/main/java/com/liberty52/product/service/entity/license/LicenseOption.java
@@ -13,6 +13,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -37,10 +38,20 @@ public class LicenseOption {
 		this.product.addLicenseOptions(this);
 	}
 
-	public LicenseOption(String name) {
+	@Builder
+	private LicenseOption(String name) {
 		this.name = name;
 	}
+
+	public static LicenseOption create(String name) {
+		return builder().name(name).build();
+	}
+
 	public void addDetail(LicenseOptionDetail licenseOptionDetail) {
 		this.licenseOptionDetails.add(licenseOptionDetail);
+	}
+
+	public void modifyLicenseOption(String name) {
+		this.name = name;
 	}
 }

--- a/src/main/java/com/liberty52/product/service/entity/license/LicenseOption.java
+++ b/src/main/java/com/liberty52/product/service/entity/license/LicenseOption.java
@@ -52,7 +52,8 @@ public class LicenseOption {
 	}
 
 	public static LicenseOption create(String name, Boolean require, Boolean onSale) {
-		return builder().name(name)
+		return builder()
+			.name(name)
 			.require(require)
 			.onSale(onSale)
 			.build();

--- a/src/main/java/com/liberty52/product/service/entity/license/LicenseOption.java
+++ b/src/main/java/com/liberty52/product/service/entity/license/LicenseOption.java
@@ -33,25 +33,38 @@ public class LicenseOption {
 	@Column(nullable = false)
 	private String name;
 
+	@Column(nullable = false)
+	private Boolean require;
+
+	@Column(nullable = false)
+	private Boolean onSale;
+
 	public void associate(Product product) {
 		this.product = product;
 		this.product.addLicenseOptions(this);
 	}
 
 	@Builder
-	private LicenseOption(String name) {
+	private LicenseOption(String name, Boolean require, Boolean onSale) {
 		this.name = name;
+		this.require = require;
+		this.onSale = onSale;
 	}
 
-	public static LicenseOption create(String name) {
-		return builder().name(name).build();
+	public static LicenseOption create(String name, Boolean require, Boolean onSale) {
+		return builder().name(name)
+			.require(require)
+			.onSale(onSale)
+			.build();
 	}
 
 	public void addDetail(LicenseOptionDetail licenseOptionDetail) {
 		this.licenseOptionDetails.add(licenseOptionDetail);
 	}
 
-	public void modifyLicenseOption(String name) {
+	public void modifyLicenseOption(String name, Boolean require, Boolean onSale) {
 		this.name = name;
+		this.require = require;
+		this.onSale = onSale;
 	}
 }

--- a/src/main/java/com/liberty52/product/service/entity/license/LicenseOptionDetail.java
+++ b/src/main/java/com/liberty52/product/service/entity/license/LicenseOptionDetail.java
@@ -2,6 +2,8 @@ package com.liberty52.product.service.entity.license;
 
 import java.util.UUID;
 
+import com.liberty52.product.service.controller.dto.LicenseOptionDetailModifyDto;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -40,9 +42,26 @@ public class LicenseOptionDetail {
 		this.onSale = onSale;
 		this.artUrl = artUrl;
 	}
+
+	public static LicenseOptionDetail create(String artName, String artistName, Integer stock, Boolean onSale,
+		String artUrl) {
+		return builder().artName(artName).artistName(artistName).stock(stock).onSale(onSale).artUrl(artUrl).build();
+	}
+
 	public void associate(LicenseOption licenseOption) {
 		this.licenseOption = licenseOption;
 		this.licenseOption.addDetail(this);
+	}
+
+	public void modifyLicenseOptionDetail(LicenseOptionDetailModifyDto dto) {
+		this.artName = dto.getArtName();
+		this.artistName = dto.getArtistName();
+		this.stock = dto.getStock();
+		this.onSale = dto.getOnSale();
+		this.artUrl = dto.getArtUrl();
+	}
+	public void updateOnSale() {
+		onSale = !onSale;
 	}
 
 }

--- a/src/main/java/com/liberty52/product/service/entity/license/LicenseOptionDetail.java
+++ b/src/main/java/com/liberty52/product/service/entity/license/LicenseOptionDetail.java
@@ -1,0 +1,48 @@
+package com.liberty52.product.service.entity.license;
+
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "license_option_detail")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LicenseOptionDetail {
+	@Id
+	private String id = UUID.randomUUID().toString();
+	@ManyToOne
+	private LicenseOption licenseOption;
+	@Column(nullable = false)
+	String artName;
+	@Column(nullable = false)
+	String artistName;
+	@Column(nullable = false)
+	Integer stock;
+	@Column(nullable = false)
+	Boolean onSale;
+	@Column(nullable = false)
+	String artUrl;
+
+	@Builder
+	private LicenseOptionDetail(String artName, String artistName, Integer stock, Boolean onSale, String artUrl) {
+		this.artName = artName;
+		this.artistName = artistName;
+		this.stock = stock;
+		this.onSale = onSale;
+		this.artUrl = artUrl;
+	}
+	public void associate(LicenseOption licenseOption) {
+		this.licenseOption = licenseOption;
+		this.licenseOption.addDetail(this);
+	}
+
+}

--- a/src/main/java/com/liberty52/product/service/entity/license/LicenseOptionDetail.java
+++ b/src/main/java/com/liberty52/product/service/entity/license/LicenseOptionDetail.java
@@ -53,12 +53,12 @@ public class LicenseOptionDetail {
 		this.licenseOption.addDetail(this);
 	}
 
-	public void modifyLicenseOptionDetail(LicenseOptionDetailModifyDto dto) {
+	public void modifyLicenseOptionDetail(LicenseOptionDetailModifyDto dto, String artUrl) {
 		this.artName = dto.getArtName();
 		this.artistName = dto.getArtistName();
 		this.stock = dto.getStock();
 		this.onSale = dto.getOnSale();
-		this.artUrl = dto.getArtUrl();
+		this.artUrl = artUrl;
 	}
 	public void updateOnSale() {
 		onSale = !onSale;

--- a/src/main/java/com/liberty52/product/service/repository/LicenseOptionDetailRepository.java
+++ b/src/main/java/com/liberty52/product/service/repository/LicenseOptionDetailRepository.java
@@ -1,0 +1,12 @@
+package com.liberty52.product.service.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.liberty52.product.service.entity.OptionDetail;
+import com.liberty52.product.service.entity.license.LicenseOptionDetail;
+
+public interface LicenseOptionDetailRepository extends JpaRepository<LicenseOptionDetail, String> {
+	Optional<LicenseOptionDetail> findByName(String name);
+}

--- a/src/main/java/com/liberty52/product/service/repository/LicenseOptionDetailRepository.java
+++ b/src/main/java/com/liberty52/product/service/repository/LicenseOptionDetailRepository.java
@@ -1,12 +1,8 @@
 package com.liberty52.product.service.repository;
 
-import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.liberty52.product.service.entity.OptionDetail;
 import com.liberty52.product.service.entity.license.LicenseOptionDetail;
 
 public interface LicenseOptionDetailRepository extends JpaRepository<LicenseOptionDetail, String> {
-	Optional<LicenseOptionDetail> findByName(String name);
 }

--- a/src/main/java/com/liberty52/product/service/repository/LicenseOptionRepository.java
+++ b/src/main/java/com/liberty52/product/service/repository/LicenseOptionRepository.java
@@ -1,0 +1,8 @@
+package com.liberty52.product.service.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.liberty52.product.service.entity.license.LicenseOption;
+
+public interface LicenseOptionRepository extends JpaRepository<LicenseOption, String> {
+}

--- a/src/test/java/com/liberty52/product/service/applicationservice/mock/LicenseOptionCreateMockTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/mock/LicenseOptionCreateMockTest.java
@@ -1,0 +1,69 @@
+package com.liberty52.product.service.applicationservice.mock;
+
+import static com.liberty52.product.global.constants.RoleConstants.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.liberty52.product.global.exception.external.notfound.ResourceNotFoundException;
+import com.liberty52.product.service.applicationservice.impl.LicenseOptionCreateServiceImpl;
+import com.liberty52.product.service.controller.dto.LicenseOptionCreateRequestDto;
+import com.liberty52.product.service.entity.Product;
+import com.liberty52.product.service.entity.license.LicenseOption;
+import com.liberty52.product.service.repository.LicenseOptionRepository;
+import com.liberty52.product.service.repository.ProductRepository;
+
+@ExtendWith(MockitoExtension.class)
+class LicenseOptionCreateMockTest {
+
+	@InjectMocks
+	LicenseOptionCreateServiceImpl licenseOptionCreateService;
+
+	@Mock
+	ProductRepository productRepository;
+
+	@Mock
+	LicenseOptionRepository licenseOptionRepository;
+
+	@Test
+	void createLicenseOptionByAdminTest() {
+		// Given
+		LicenseOptionCreateRequestDto dto = new LicenseOptionCreateRequestDto("testName", true, true);
+		String productId = "testProductId";
+
+		Product mockProduct = mock(Product.class);
+		when(productRepository.findById(productId)).thenReturn(Optional.of(mockProduct));
+
+		// When
+		licenseOptionCreateService.createLicenseOptionByAdmin(ADMIN, dto, productId);
+
+		// Then
+		ArgumentCaptor<LicenseOption> captor = ArgumentCaptor.forClass(LicenseOption.class);
+		verify(licenseOptionRepository, times(1)).save(captor.capture());
+
+		assertEquals("testName", captor.getValue().getName());
+		assertEquals(true, captor.getValue().getRequire());
+		assertEquals(true, captor.getValue().getOnSale());
+	}
+
+	@Test
+	void createLicenseOptionByAdminTest_ProductNotFound() {
+		// Given
+		LicenseOptionCreateRequestDto dto = new LicenseOptionCreateRequestDto("testName", true, true);
+		String productId = "testProductId";
+		// When
+		when(productRepository.findById(productId)).thenReturn(Optional.empty());
+		// Then
+		assertThrows(ResourceNotFoundException.class,
+			() -> licenseOptionCreateService.createLicenseOptionByAdmin(ADMIN, dto, productId));
+	}
+}

--- a/src/test/java/com/liberty52/product/service/applicationservice/mock/LicenseOptionDetailCreateMockTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/mock/LicenseOptionDetailCreateMockTest.java
@@ -1,0 +1,117 @@
+package com.liberty52.product.service.applicationservice.mock;
+
+import static com.liberty52.product.global.constants.RoleConstants.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.liberty52.product.global.adapter.s3.S3UploaderApi;
+import com.liberty52.product.global.exception.external.badrequest.BadRequestException;
+import com.liberty52.product.service.applicationservice.impl.LicenseOptionDetailCreateServiceImpl;
+import com.liberty52.product.service.controller.dto.LicenseOptionDetailCreateDto;
+import com.liberty52.product.service.entity.license.LicenseOption;
+import com.liberty52.product.service.entity.license.LicenseOptionDetail;
+import com.liberty52.product.service.repository.LicenseOptionDetailRepository;
+import com.liberty52.product.service.repository.LicenseOptionRepository;
+
+@ExtendWith(MockitoExtension.class)
+class LicenseOptionDetailCreateMockTest {
+
+	@InjectMocks
+	LicenseOptionDetailCreateServiceImpl licenseOptionDetailCreateService;
+
+	@Mock
+	LicenseOptionRepository licenseOptionRepository;
+
+	@Mock
+	LicenseOptionDetailRepository licenseOptionDetailRepository;
+
+	@Mock
+	S3UploaderApi s3Uploader;
+
+	@Test
+	void createLicenseOptionDetailByAdminTest() {
+		// Given
+		String licenseOptionId = "testLicenseOptionId";
+		LicenseOptionDetailCreateDto dto = LicenseOptionDetailCreateDto.create
+			("testArtName", "testArtistName", 100, true);
+		MultipartFile artImageFile = mock(MultipartFile.class);
+		LicenseOption mockLicenseOption = mock(LicenseOption.class);
+
+		when(licenseOptionRepository.findById(licenseOptionId)).thenReturn(Optional.of(mockLicenseOption));
+		when(s3Uploader.upload(artImageFile)).thenReturn("testArtUrl");
+
+		// When
+		licenseOptionDetailCreateService.createLicenseOptionDetailByAdmin(ADMIN, dto, licenseOptionId, artImageFile);
+
+		// Then
+		ArgumentCaptor<LicenseOptionDetail> captor = ArgumentCaptor.forClass(LicenseOptionDetail.class);
+		verify(licenseOptionDetailRepository, times(1)).save(captor.capture());
+		LicenseOptionDetail savedLicenseOptionDetail = captor.getValue();
+		assertEquals(dto.getArtName(), savedLicenseOptionDetail.getArtName());
+		assertEquals(dto.getArtistName(), savedLicenseOptionDetail.getArtistName());
+		assertEquals(dto.getStock(), savedLicenseOptionDetail.getStock());
+		assertEquals(dto.getOnSale(), savedLicenseOptionDetail.getOnSale());
+		assertEquals("testArtUrl", savedLicenseOptionDetail.getArtUrl());
+	}
+
+	@Test
+	void createLicenseOptionDetailByAdmin_WhenLicenseOptionNotFound_ThrowException() {
+		// Given
+		String licenseOptionId = "testLicenseOptionId";
+		LicenseOptionDetailCreateDto dto = LicenseOptionDetailCreateDto.create
+			("testArtName", "testArtistName", 100, true);
+		MultipartFile artImageFile = mock(MultipartFile.class);
+
+		when(licenseOptionRepository.findById(licenseOptionId)).thenReturn(Optional.empty());
+
+		// When
+		// Then
+		assertThrows(RuntimeException.class, () -> {
+			licenseOptionDetailCreateService.createLicenseOptionDetailByAdmin(ADMIN, dto, licenseOptionId,
+				artImageFile);
+		});
+	}
+
+	@Test
+	void createLicenseOptionDetailByAdmin_WhenRoleIsNotAdmin() {
+		// Given
+		String licenseOptionId = "testLicenseOptionId";
+		LicenseOptionDetailCreateDto dto = LicenseOptionDetailCreateDto.create
+			("testArtName", "testArtistName", 100, true);
+		MultipartFile artImageFile = mock(MultipartFile.class);
+
+		// When
+		// Then
+		assertThrows(RuntimeException.class, () -> {
+			licenseOptionDetailCreateService.createLicenseOptionDetailByAdmin("USER", dto, licenseOptionId,
+				artImageFile);
+		});
+	}
+
+	@Test
+	void createLicenseOptionDetailByAdmin_WhenArtImageFileIsNull() {
+		// Given
+		String licenseOptionId = "testLicenseOptionId";
+		LicenseOptionDetailCreateDto dto = LicenseOptionDetailCreateDto.create
+			("testArtName", "testArtistName", 100, true);
+		MultipartFile artImageFile = null;
+		LicenseOption mockLicenseOption = mock(LicenseOption.class);
+
+		when(licenseOptionRepository.findById(licenseOptionId)).thenReturn(Optional.of(mockLicenseOption));
+		// When
+		// Then
+		assertThrows(BadRequestException.class,
+			() -> licenseOptionDetailCreateService.createLicenseOptionDetailByAdmin(ADMIN, dto, licenseOptionId, artImageFile));
+
+	}
+}

--- a/src/test/java/com/liberty52/product/service/applicationservice/mock/LicenseOptionDetailModifyMockTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/mock/LicenseOptionDetailModifyMockTest.java
@@ -1,0 +1,120 @@
+package com.liberty52.product.service.applicationservice.mock;
+
+import static com.liberty52.product.global.constants.RoleConstants.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.liberty52.product.global.adapter.s3.S3UploaderApi;
+import com.liberty52.product.global.exception.external.badrequest.BadRequestException;
+import com.liberty52.product.global.exception.external.notfound.ResourceNotFoundException;
+import com.liberty52.product.service.applicationservice.impl.LicenseOptionDetailModifyServiceImpl;
+import com.liberty52.product.service.controller.dto.LicenseOptionDetailModifyDto;
+import com.liberty52.product.service.entity.license.LicenseOptionDetail;
+import com.liberty52.product.service.repository.LicenseOptionDetailRepository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class LicenseOptionDetailModifyMockTest {
+
+	@InjectMocks
+	LicenseOptionDetailModifyServiceImpl licenseOptionDetailModifyService;
+
+	@Mock
+	LicenseOptionDetailRepository licenseOptionDetailRepository;
+
+	@Mock
+	S3UploaderApi s3Uploader;
+
+	@Test
+	void modifyLicenseOptionDetailByAdminTest() {
+		// Given
+		String licenseOptionDetailId = "testLicenseOptionDetailId";
+		LicenseOptionDetailModifyDto dto = new LicenseOptionDetailModifyDto("ArtName", "ArtistName", 10, true);
+		MultipartFile artImageFile = mock(MultipartFile.class);
+
+		LicenseOptionDetail mockLicenseOptionDetail = mock(LicenseOptionDetail.class);
+		when(licenseOptionDetailRepository.findById(licenseOptionDetailId)).thenReturn(
+			Optional.of(mockLicenseOptionDetail));
+		when(s3Uploader.upload(artImageFile)).thenReturn("modifiedArtUrl");
+
+		// When
+		licenseOptionDetailModifyService.modifyLicenseOptionDetailByAdmin(ADMIN, licenseOptionDetailId, dto,
+			artImageFile);
+
+		// Then
+		verify(mockLicenseOptionDetail, times(1)).modifyLicenseOptionDetail(dto, "modifiedArtUrl");
+	}
+
+	@Test
+	void modifyLicenseOptionDetailByAdmin_When_LicenseOptionDetailNotFoundTest() {
+		// Given
+		String licenseOptionDetailId = "testLicenseOptionDetailId";
+		LicenseOptionDetailModifyDto dto = new LicenseOptionDetailModifyDto("ArtName", "ArtistName", 10, true);
+		MultipartFile artImageFile = mock(MultipartFile.class);
+
+		when(licenseOptionDetailRepository.findById(licenseOptionDetailId)).thenReturn(Optional.empty());
+
+		assertThrows(
+			ResourceNotFoundException.class,
+			() -> licenseOptionDetailModifyService.modifyLicenseOptionDetailByAdmin(ADMIN, licenseOptionDetailId, dto,
+				artImageFile));
+	}
+
+	@Test
+	void modifyLicenseOptionDetailByAdmin_When_ArtImageFileIsNullTest() {
+		// Given
+		String licenseOptionDetailId = "testLicenseOptionDetailId";
+		LicenseOptionDetailModifyDto dto = new LicenseOptionDetailModifyDto("ArtName", "ArtistName", 10, true);
+		MultipartFile artImageFile = null;
+
+		LicenseOptionDetail mockLicenseOptionDetail = mock(LicenseOptionDetail.class);
+		when(licenseOptionDetailRepository.findById(licenseOptionDetailId)).thenReturn(
+			Optional.of(mockLicenseOptionDetail));
+
+		// When
+		// Then
+		assertThrows(BadRequestException.class,
+			() -> licenseOptionDetailModifyService.modifyLicenseOptionDetailByAdmin(ADMIN, licenseOptionDetailId, dto,
+				artImageFile));
+	}
+
+	@Test
+	void modifyLicenseOptionDetailOnSailStateByAdminTest() {
+		// Given
+		String licenseOptionDetailId = "testLicenseOptionDetailId";
+
+		LicenseOptionDetail mockLicenseOptionDetail = mock(LicenseOptionDetail.class);
+		when(licenseOptionDetailRepository.findById(licenseOptionDetailId)).thenReturn(
+			Optional.of(mockLicenseOptionDetail));
+
+		// When
+		licenseOptionDetailModifyService.modifyLicenseOptionDetailOnSailStateByAdmin(ADMIN, licenseOptionDetailId);
+
+		// Then
+		verify(mockLicenseOptionDetail, times(1)).updateOnSale();
+	}
+
+	@Test
+	void modifyLicenseOptionDetailOnSailStateByAdmin_When_LicenseOptionDetailNotFoundTest() {
+		// Given
+		String licenseOptionDetailId = "testLicenseOptionDetailId";
+
+		when(licenseOptionDetailRepository.findById(licenseOptionDetailId)).thenReturn(Optional.empty());
+
+		// When
+		// Then
+		assertThrows(
+			ResourceNotFoundException.class,
+			() -> licenseOptionDetailModifyService.modifyLicenseOptionDetailOnSailStateByAdmin(ADMIN,
+				licenseOptionDetailId));
+	}
+}

--- a/src/test/java/com/liberty52/product/service/applicationservice/mock/LicenseOptionModifyMockTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/mock/LicenseOptionModifyMockTest.java
@@ -1,0 +1,59 @@
+package com.liberty52.product.service.applicationservice.mock;
+
+import static com.liberty52.product.global.constants.RoleConstants.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.liberty52.product.global.exception.external.notfound.ResourceNotFoundException;
+import com.liberty52.product.service.applicationservice.impl.LicenseOptionModifyServiceImpl;
+import com.liberty52.product.service.controller.dto.LicenseOptionModifyRequestDto;
+import com.liberty52.product.service.entity.license.LicenseOption;
+import com.liberty52.product.service.repository.LicenseOptionRepository;
+
+@ExtendWith(MockitoExtension.class)
+class LicenseOptionModifyMockTest {
+
+	@InjectMocks
+	LicenseOptionModifyServiceImpl licenseOptionModifyService;
+
+	@Mock
+	LicenseOptionRepository licenseOptionRepository;
+
+	@Test
+	void modifyLicenseOptionByAdminTest() {
+		// Given
+		String licenseOptionId = "testLicenseOptionId";
+		LicenseOptionModifyRequestDto dto = new LicenseOptionModifyRequestDto("modifiedName", false, true);
+
+		LicenseOption mockLicenseOption = mock(LicenseOption.class);
+		when(licenseOptionRepository.findById(licenseOptionId)).thenReturn(Optional.of(mockLicenseOption));
+
+		// When
+		licenseOptionModifyService.modifyLicenseOptionByAdmin(ADMIN, licenseOptionId, dto);
+
+		// Then
+		verify(mockLicenseOption, times(1)).modifyLicenseOption(dto.getName(), dto.getRequire(), dto.getOnSale());
+	}
+
+	@Test
+	void modifyLicenseOptionByAdminTest_LicenseOptionNotFound() {
+		// Given
+		String licenseOptionId = "testLicenseOptionId";
+		LicenseOptionModifyRequestDto dto = new LicenseOptionModifyRequestDto("modifiedName", false, true);
+
+		when(licenseOptionRepository.findById(licenseOptionId)).thenReturn(Optional.empty());
+
+		// Then
+		assertThrows(ResourceNotFoundException.class,
+			() -> licenseOptionModifyService.modifyLicenseOptionByAdmin(ADMIN, licenseOptionId, dto));
+	}
+}

--- a/src/test/java/com/liberty52/product/service/applicationservice/mock/LicenseProductInfoRetrieveMockTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/mock/LicenseProductInfoRetrieveMockTest.java
@@ -1,0 +1,85 @@
+package com.liberty52.product.service.applicationservice.mock;
+
+import static com.liberty52.product.global.constants.RoleConstants.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.liberty52.product.global.exception.external.notfound.ResourceNotFoundException;
+import com.liberty52.product.service.applicationservice.impl.LicenseProductInfoRetrieveServiceImpl;
+import com.liberty52.product.service.controller.dto.LicenseOptionInfoResponseDto;
+import com.liberty52.product.service.entity.Product;
+import com.liberty52.product.service.entity.license.LicenseOption;
+import com.liberty52.product.service.entity.license.LicenseOptionDetail;
+import com.liberty52.product.service.repository.ProductRepository;
+
+@ExtendWith(MockitoExtension.class)
+class LicenseProductInfoRetrieveMockTest {
+
+	@InjectMocks
+	LicenseProductInfoRetrieveServiceImpl licenseProductInfoRetrieveService;
+
+	@Mock
+	ProductRepository productRepository;
+
+	@Test
+	void retrieveLicenseProductOptionInfoListByAdminTest() {
+		// Given
+		String productId = "testProductId";
+		boolean onSale = true;
+
+		LicenseOptionDetail licenseOptionDetail1 = LicenseOptionDetail.create("testArtName1", "testArtistName1", 100,
+			true, "testArtUrl1");
+		LicenseOptionDetail licenseOptionDetail2 = LicenseOptionDetail.create("testArtName2", "testArtistName2", 100,
+			true, "testArtUrl2");
+
+		Product mockProduct = mock(Product.class);
+		when(productRepository.findById(productId)).thenReturn(Optional.of(mockProduct));
+
+		List<LicenseOptionDetail> licenseOptionDetails = Arrays.asList(licenseOptionDetail1, licenseOptionDetail2);
+
+		LicenseOption licenseOption1 = mock(LicenseOption.class);
+		when(licenseOption1.getLicenseOptionDetails()).thenReturn(licenseOptionDetails);
+		when(licenseOption1.getId()).thenReturn("testOption1");
+		when(licenseOption1.getRequire()).thenReturn(true);
+		when(licenseOption1.getOnSale()).thenReturn(true);
+		List<LicenseOption> licenseOptions = List.of(licenseOption1);
+
+		when(mockProduct.getLicenseOptions()).thenReturn(licenseOptions);
+
+		// When
+		List<LicenseOptionInfoResponseDto> result = licenseProductInfoRetrieveService.retrieveLicenseProductOptionInfoListByAdmin(
+			ADMIN, productId, onSale);
+
+		// Then
+		assertEquals(1, result.size());
+		assertEquals("testOption1", result.get(0).getLicenseOptionId());
+		assertEquals("testArtName1", result.get(0).getLicenseOptionDetailList().get(0).getArtName());
+		assertEquals("testArtName2", result.get(0).getLicenseOptionDetailList().get(1).getArtName());
+	}
+
+	@Test
+	void retrieveLicenseProductOptionInfoListByAdmin_When_Product_Not_Found_Test() {
+		// Given
+		String productId = "testProductId";
+		boolean onSale = true;
+
+		when(productRepository.findById(productId)).thenReturn(Optional.empty());
+
+		// When
+		// Then
+		assertThrows(ResourceNotFoundException.class,
+			() -> licenseProductInfoRetrieveService.retrieveLicenseProductOptionInfoListByAdmin(ADMIN, productId,
+				onSale));
+	}
+}


### PR DESCRIPTION
## 스프린트 넘버  : 6
## 메이저 마일스톤 : 관리자
### 백로그 이름 : 라이선스 상품 옵션 CRUD 

***
### 작업
- 라이선스 상품 옵션 생성
- 라이선스 상품 옵션 수정
- 라이선스 상품 옵션 조회

### API
API 문서에 업데이트 예정입니다.
***
### 테스트 결과
![image](https://github.com/Liberty52/product/assets/55132026/640e8176-5110-4dc6-877a-6bc34d08d7e4)


***
### 이슈
- 추후에 라이선스 상품 구매 시 수량 동기화 관련(분산락) 로직 추가 예정입니다.
