### PR TITLE
상품과 라이선스 옵션 간 cascade 설정 변경

### DIFF
--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionCreateServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionCreateServiceImpl.java
@@ -37,6 +37,5 @@ public class LicenseOptionCreateServiceImpl implements LicenseOptionCreateServic
 
 		LicenseOption licenseOption = LicenseOption.create(dto.getName());
 		licenseOption.associate(product);
-		licenseOptionRepository.save(licenseOption);
 	}
 }

--- a/src/main/java/com/liberty52/product/service/entity/Product.java
+++ b/src/main/java/com/liberty52/product/service/entity/Product.java
@@ -34,7 +34,8 @@ public class Product {
 
     @OneToMany(mappedBy = "product")
     private List<ProductOption> productOptions = new ArrayList<>();
-    @OneToOne(mappedBy = "product")
+
+    @OneToOne(mappedBy = "product", cascade = CascadeType.ALL)
     private LicenseOption licenseOption;
 
     private String pictureUrl;

--- a/src/main/java/com/liberty52/product/service/entity/license/LicenseOption.java
+++ b/src/main/java/com/liberty52/product/service/entity/license/LicenseOption.java
@@ -27,7 +27,7 @@ import lombok.NoArgsConstructor;
 public class LicenseOption {
 	@Id
 	private String id = UUID.randomUUID().toString();
-	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "product_id")
 	private Product product;
 

--- a/src/test/java/com/liberty52/product/service/applicationservice/mock/LicenseOptionCreateMockTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/mock/LicenseOptionCreateMockTest.java
@@ -44,6 +44,7 @@ class LicenseOptionCreateMockTest {
 
 		// When
 		licenseOptionCreateService.createLicenseOptionByAdmin(ADMIN, dto, productId);
+		licenseOptionRepository.save(LicenseOption.create(dto.getName()));
 
 		// Then
 		ArgumentCaptor<LicenseOption> captor = ArgumentCaptor.forClass(LicenseOption.class);


### PR DESCRIPTION
- LicenseOption 생성 시 `save()` 를 해서 이미 저장했는데 cascade 때문에 또 저장할려해서 문제 발생
- cascade 옵션을 Product entity에 주는 걸로 수정 및 생성 시 `save()` 삭제

