### PR TITLE
[issue-355]: liberty-authentication-library 모듈을 product 모듈에 추가하고 빌드

### DIFF
--- a/multistage.Dockerfile
+++ b/multistage.Dockerfile
@@ -3,6 +3,10 @@ WORKDIR /app
 COPY build.gradle .
 COPY settings.gradle .
 COPY src src
+
+COPY liberty-authentication-library liberty-authentication-library
+RUN gradle :liberty-authentication-library:assemble
+
 RUN gradle assemble
 
 FROM openjdk:17-alpine


### PR DESCRIPTION


***
### 작업
-  liberty-authentication-library 모듈을 product 모듈에 추가하고 빌드


**CODE** 
```dockerfile
FROM gradle:7.4-jdk17 AS builder
WORKDIR /app
COPY build.gradle .
COPY settings.gradle .
COPY src src

COPY liberty-authentication-library liberty-authentication-library
RUN gradle :liberty-authentication-library:assemble

RUN gradle assemble

FROM openjdk:17-alpine
VOLUME /tmp
ARG JAR_FILE=/app/build/libs/*.jar
COPY --from=builder ${JAR_FILE} app.jar
EXPOSE 8080
ARG SPRING_PROFILES_ACTIVE=dev
ENV SPRING_PROFILES_ACTIVE=$SPRING_PROFILES_ACTIVE
ENV TZ=Asia/Seoul
ENTRYPOINT ["java","-jar", "app.jar", "-Xmx2g", "-Xms256m", "-Dspring.profiles.active=${SPRING_PROFILES_ACTIVE}"]

```



***
### 테스트 결과

```shell
imkunyoung@ImKunYoung:~/product$ docker build -t test -f multistage.Dockerfile .
[+] Building 126.9s (18/18) FINISHED
 => [internal] load build definition from multistage.Dockerfile                                                                                                  0.0s 
 => => transferring dockerfile: 43B                                                                                                                              0.0s 
 => [internal] load .dockerignore                                                                                                                                0.0s 
 => => transferring context: 2B                                                                                                                                  0.0s 
 => [internal] load metadata for docker.io/library/gradle:7.4-jdk17                                                                                              2.0s 
 => [internal] load metadata for docker.io/library/openjdk:17-alpine                                                                                             2.0s 
 => [auth] library/openjdk:pull token for registry-1.docker.io                                                                                                   0.0s 
 => [auth] library/gradle:pull token for registry-1.docker.io                                                                                                    0.0s 
 => [builder 1/8] FROM docker.io/library/gradle:7.4-jdk17@sha256:ce56c8bbe223806848aee26c58d05d3d797049a67b22d8a80fbb5af93e958e18                                0.0s 
 => [internal] load build context                                                                                                                                0.3s :pull token for registry-1.docker.io                                                                                                   0.0s
 => => transferring context: 297.22kB                                                                                                                            0.2s 
 => CACHED [stage-1 1/2] FROM docker.io/library/openjdk:17-alpine@sha256:4b6abae565492dbe9e7a894137c966a7485154238902f2f25e9dbd9784383d81                        0.0s 
 => CACHED [builder 2/8] WORKDIR /app                                                                                                                            0.0s 
 => CACHED [builder 3/8] COPY build.gradle .                                                                                                                     0.0s 
 => CACHED [builder 4/8] COPY settings.gradle .                                                                                                                  0.0s 
 => CACHED [builder 5/8] COPY src src                                                                                                                            0.0s 
 => [builder 6/8] COPY liberty-authentication-library liberty-authentication-library                                                                             0.1s 
 => [builder 7/8] RUN gradle :liberty-authentication-library:assemble                                                                                           37.5s 
 => [builder 8/8] RUN gradle assemble                                                                                                                           84.0s 
 => [stage-1 2/2] COPY --from=builder /app/build/libs/*.jar app.jar                                                                                              0.3s
 => exporting to image                                                                                                                                           0.8s
 => => exporting layers                                                                                                                                          0.8s
 => => writing image sha256:2d05023e9b183564650eb8632b74b38aa5dbb97c618a9c8fe318b451435b5d6e                                                                     0.0s
 => => naming to docker.io/library/test                                                                                                                          0.0s
```

***
### 이슈
Closes #355 
Related #352 