### PR TITLE
라이선스 상품 주문 생성

### DIFF
--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionDetailModifyServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/LicenseOptionDetailModifyServiceImpl.java
@@ -5,7 +5,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.liberty52.product.global.adapter.s3.S3UploaderApi;
-import com.liberty52.product.global.exception.external.badrequest.BadRequestException;
 import com.liberty52.product.global.exception.external.notfound.ResourceNotFoundException;
 import com.liberty52.product.global.util.Validator;
 import com.liberty52.product.service.applicationservice.LicenseOptionDetailModifyService;
@@ -28,10 +27,10 @@ public class LicenseOptionDetailModifyServiceImpl implements LicenseOptionDetail
 		Validator.isAdmin(role);
 		LicenseOptionDetail licenseOptionDetail = licenseOptionDetailRepository.findById(licenseOptionDetailId)
 			.orElseThrow(() -> new ResourceNotFoundException("OptionDetail", "ID", licenseOptionDetailId));
-		if (artImageFile == null) {
-			throw new BadRequestException("라이선스 이미지가 없습니다.");
+		if (artImageFile != null){
+			licenseOptionDetail.modifyLicenseArtUrl(s3Uploader.upload(artImageFile));
 		}
-		licenseOptionDetail.modifyLicenseOptionDetail(dto, s3Uploader.upload(artImageFile));
+		licenseOptionDetail.modifyLicenseOptionDetail(dto);
 	}
 
 	@Override

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/OrderCreateServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/OrderCreateServiceImpl.java
@@ -54,6 +54,7 @@ public class OrderCreateServiceImpl implements OrderCreateService {
 	private final OrdersRepository ordersRepository;
 	private final OptionDetailRepository optionDetailRepository;
 	private final CustomProductOptionRepository customProductOptionRepository;
+	private final CustomLicenseOptionRepository customLicenseOptionRepository;
 	private final LicenseOptionDetailRepository licenseOptionDetailRepository;
 	private final ConfirmPaymentMapRepository confirmPaymentMapRepository;
 	private final VBankRepository vBankRepository;
@@ -156,7 +157,7 @@ public class OrderCreateServiceImpl implements OrderCreateService {
 					dto.getProductDto().getOptionDetailIds().get(0)));
 			CustomProduct customProduct = this.createLicenseCustomProduct(authId, dto, product, order);
 			this.createCustomLicenseOption(customProduct, licenseOptionDetail);
-
+			customProductRepository.save(customProduct);
 		} else {
 			List<OptionDetail> optionDetails = this.getOptionDetails(dto);
 			String imgUrl = s3Uploader.upload(imageFile);
@@ -239,6 +240,7 @@ public class OrderCreateServiceImpl implements OrderCreateService {
 		CustomLicenseOption customLicenseOption = CustomLicenseOption.create();
 		customLicenseOption.associate(detail);
 		customLicenseOption.associate(customProduct);
+		customLicenseOptionRepository.save(customLicenseOption);
 	}
 
     private void saveCardPayment(Orders order) {

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/OrderCreateServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/OrderCreateServiceImpl.java
@@ -154,7 +154,7 @@ public class OrderCreateServiceImpl implements OrderCreateService {
 					dto.getProductDto().getOptionDetailIds().get(0))
 				.orElseThrow(() -> new ResourceNotFoundException("LICENSE_OPTION_DETAIL", "ID",
 					dto.getProductDto().getOptionDetailIds().get(0)));
-			CustomProduct customProduct = this.createLicenseCustomProduct(authId, dto, product, order, "");
+			CustomProduct customProduct = this.createLicenseCustomProduct(authId, dto, product, order);
 			this.createCustomLicenseOption(customProduct, licenseOptionDetail);
 
 		} else {
@@ -221,8 +221,8 @@ public class OrderCreateServiceImpl implements OrderCreateService {
         return customProduct;
     }
 
-	private CustomProduct createLicenseCustomProduct(String authId, OrderCreateRequestDto dto, Product product, Orders order, String imgUrl) {
-		CustomProduct customProduct = CustomProduct.create(imgUrl, dto.getProductDto().getQuantity(), authId);
+	private CustomProduct createLicenseCustomProduct(String authId, OrderCreateRequestDto dto, Product product, Orders order) {
+		CustomProduct customProduct = CustomProduct.create("", dto.getProductDto().getQuantity(), authId);
 		customProduct.associateWithProduct(product);
 		customProduct.associateWithOrder(order);
 		return customProduct;

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/OrderStatusModifyServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/OrderStatusModifyServiceImpl.java
@@ -49,8 +49,6 @@ public class OrderStatusModifyServiceImpl implements OrderStatusModifyService {
   @Override
   public void modifyOrderStatusOfVBankByAdmin(String role, String orderId, VBankStatusModifyDto dto) {
     Validator.isAdmin(role);
-    BankType.getBankType(dto.getDepositorBank());
-
     Orders order = ordersRepository.findById(orderId)
         .orElseThrow(() -> new OrderNotFoundByIdException(orderId));
 

--- a/src/main/java/com/liberty52/product/service/controller/OrderController.java
+++ b/src/main/java/com/liberty52/product/service/controller/OrderController.java
@@ -68,7 +68,7 @@ public class OrderController {
     public PaymentCardResponseDto createCardPaymentOrders(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authId,
             @RequestPart("dto") @Validated OrderCreateRequestDto dto,
-            @RequestPart("imageFile") MultipartFile imageFile
+            @RequestPart(value = "imageFile", required = false) MultipartFile imageFile
     ) {
         return orderCreateService.createCardPaymentOrders(authId, dto, imageFile);
     }
@@ -90,7 +90,7 @@ public class OrderController {
     public PaymentVBankResponseDto createVBankPaymentOrders(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authId,
             @RequestPart("dto") @Validated OrderCreateRequestDto dto,
-            @RequestPart("imageFile") MultipartFile imageFile
+            @RequestPart(value = "imageFile", required = false) MultipartFile imageFile
     ) {
         return orderCreateService.createVBankPaymentOrders(authId, dto, imageFile);
     }

--- a/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionDetailInfoResponseDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/LicenseOptionDetailInfoResponseDto.java
@@ -19,6 +19,7 @@ public class LicenseOptionDetailInfoResponseDto {
 	Integer stock;
 	Boolean onSale;
 	String artUrl;
+	Integer price;
 	LocalDate startDate;
 	LocalDate endDate;
 
@@ -27,6 +28,7 @@ public class LicenseOptionDetailInfoResponseDto {
 		artName = licenseOptionDetail.getArtName();
 		artistName = licenseOptionDetail.getArtistName();
 		stock = licenseOptionDetail.getStock();
+		price = licenseOptionDetail.getPrice();
 		onSale = licenseOptionDetail.getOnSale();
 		artUrl = licenseOptionDetail.getArtUrl();
 		startDate = licenseOptionDetail.getStartDate();

--- a/src/main/java/com/liberty52/product/service/controller/dto/OrderDetailRetrieveResponse.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/OrderDetailRetrieveResponse.java
@@ -58,7 +58,8 @@ public class OrderDetailRetrieveResponse {
                             .sum(),
                     c.getUserCustomPictureUrl(),
                     c.getReview() != null,
-                    c.getOptions().stream().map(CustomProductOption::getDetailName).toList()
+                    c.getOptions().stream().map(CustomProductOption::getDetailName).toList(),
+                    c.getProduct().isCustom()
             )
         ).toList();
         this.deliveryFee = orders.getDeliveryPrice();

--- a/src/main/java/com/liberty52/product/service/controller/dto/OrderRetrieveProductResponse.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/OrderRetrieveProductResponse.java
@@ -21,6 +21,8 @@ public class OrderRetrieveProductResponse {
     private List<String> options;
     private boolean hasReview;
 
+    private boolean isCustom;
+
 
     @QueryProjection
     public OrderRetrieveProductResponse(String name, int quantity, Long price) {
@@ -30,7 +32,8 @@ public class OrderRetrieveProductResponse {
     }
 
     @QueryProjection
-    public OrderRetrieveProductResponse(String customProductId, String name, int quantity, Long price, String productUrl, boolean hasReview, List<String> options) {
+    public OrderRetrieveProductResponse(String customProductId, String name, int quantity, Long price, String productUrl,
+        boolean hasReview, List<String> options, boolean isCustom) {
         this.customProductId = customProductId;
         this.name = name;
         this.quantity = quantity;
@@ -38,5 +41,6 @@ public class OrderRetrieveProductResponse {
         this.productUrl = productUrl;
         this.options = options;
         this.hasReview = hasReview;
+        this.isCustom = isCustom;
     }
 }

--- a/src/main/java/com/liberty52/product/service/controller/dto/OrdersRetrieveResponse.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/OrdersRetrieveResponse.java
@@ -57,7 +57,8 @@ public class OrdersRetrieveResponse {
                                 .sum(),
                         c.getUserCustomPictureUrl(),
                         c.getReview() != null,
-                        c.getOptions().stream().map(CustomProductOption::getDetailName).toList()
+                        c.getOptions().stream().map(CustomProductOption::getDetailName).toList(),
+                        c.getProduct().isCustom()
                 )
         ).toList();
     }

--- a/src/main/java/com/liberty52/product/service/controller/license/LicenseOptionDetailAdminController.java
+++ b/src/main/java/com/liberty52/product/service/controller/license/LicenseOptionDetailAdminController.java
@@ -44,7 +44,7 @@ public class LicenseOptionDetailAdminController {
 		@RequestHeader("LB-Role") String role,
 		@PathVariable String licenseOptionDetailId,
 		@Validated @RequestPart(value = "dto") LicenseOptionDetailModifyDto dto,
-		@RequestPart(value = "file") MultipartFile imageFile
+		@RequestPart(value = "file", required = false) MultipartFile imageFile
 	) {
 		licenseOptionDetailModifyService.modifyLicenseOptionDetailByAdmin(role, licenseOptionDetailId, dto, imageFile);
 	}

--- a/src/main/java/com/liberty52/product/service/entity/CustomProduct.java
+++ b/src/main/java/com/liberty52/product/service/entity/CustomProduct.java
@@ -53,7 +53,7 @@ public class CustomProduct {
     @OneToOne(fetch = FetchType.LAZY, mappedBy = "customProduct", cascade = CascadeType.ALL)
     private Review review;
 
-    @OneToOne(fetch = FetchType.LAZY, mappedBy = "customProduct")
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "license_product_option_id")
     private CustomLicenseOption customLicenseOption;
 
@@ -109,7 +109,7 @@ public class CustomProduct {
         this.review = review;
         this.review.associate(this);
     }
-    public void associateWithLicenseProductOption(CustomLicenseOption customLicenseOption) {
+    public void associateWithCustomLicenseOption(CustomLicenseOption customLicenseOption) {
         Objects.requireNonNull(customLicenseOption);
         this.customLicenseOption = customLicenseOption;
     }

--- a/src/main/java/com/liberty52/product/service/entity/CustomProduct.java
+++ b/src/main/java/com/liberty52/product/service/entity/CustomProduct.java
@@ -2,6 +2,8 @@ package com.liberty52.product.service.entity;
 
 import com.liberty52.product.global.exception.external.badrequest.CartAddInvalidItemException;
 import com.liberty52.product.global.exception.internal.InvalidQuantityException;
+import com.liberty52.product.service.entity.license.CustomLicenseOption;
+
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -50,6 +52,10 @@ public class CustomProduct {
 
     @OneToOne(fetch = FetchType.LAZY, mappedBy = "customProduct", cascade = CascadeType.ALL)
     private Review review;
+
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "customProduct")
+    @JoinColumn(name = "license_product_option_id")
+    private CustomLicenseOption customLicenseOption;
 
     public Map<String, String> getOptionsMap() {
         Map<String, String> optionsMap = new HashMap<>();
@@ -102,6 +108,10 @@ public class CustomProduct {
         Objects.requireNonNull(review);
         this.review = review;
         this.review.associate(this);
+    }
+    public void associateWithLicenseProductOption(CustomLicenseOption customLicenseOption) {
+        Objects.requireNonNull(customLicenseOption);
+        this.customLicenseOption = customLicenseOption;
     }
 
     public void dissociateCart() {

--- a/src/main/java/com/liberty52/product/service/entity/Orders.java
+++ b/src/main/java/com/liberty52/product/service/entity/Orders.java
@@ -117,17 +117,22 @@ public class Orders {
     private void calcTotalAmountAndSet() {
         AtomicLong totalAmount = new AtomicLong();
 
-        this.customProducts.forEach(customProduct -> {
-            // 기본금
-            totalAmount.getAndAdd(customProduct.getProduct().getPrice());
-            // 옵션 추가금액
-            customProduct.getOptions().forEach(customProductOption ->
-                        totalAmount.getAndAdd(customProductOption.getOptionDetail().getPrice()));
-            // 수량
-            totalAmount.getAndUpdate(x -> customProduct.getQuantity() * x);
-        });
-        // 배송비
-        totalAmount.getAndAdd(this.deliveryPrice);
+		this.customProducts.forEach(customProduct -> {
+			// 기본금
+			totalAmount.getAndAdd(customProduct.getProduct().getPrice());
+			// 옵션 추가금액
+			if (!customProduct.getProduct().isCustom()) {
+				totalAmount.getAndAdd(customProduct.getCustomLicenseOption().getLicenseOptionDetail().getPrice());
+			} else {
+				customProduct.getOptions().forEach(customProductOption ->
+					totalAmount.getAndAdd(customProductOption.getOptionDetail().getPrice()));
+			}
+
+			// 수량
+			totalAmount.getAndUpdate(x -> customProduct.getQuantity() * x);
+		});
+		// 배송비
+		totalAmount.getAndAdd(this.deliveryPrice);
 
         this.amount = totalAmount.get();
     }

--- a/src/main/java/com/liberty52/product/service/entity/Product.java
+++ b/src/main/java/com/liberty52/product/service/entity/Product.java
@@ -35,7 +35,7 @@ public class Product {
     @OneToMany(mappedBy = "product")
     private List<ProductOption> productOptions = new ArrayList<>();
 
-    @OneToOne(mappedBy = "product", cascade = CascadeType.ALL)
+    @OneToOne(mappedBy = "product", cascade = CascadeType.PERSIST)
     private LicenseOption licenseOption;
 
     private String pictureUrl;

--- a/src/main/java/com/liberty52/product/service/entity/license/CustomLicenseOption.java
+++ b/src/main/java/com/liberty52/product/service/entity/license/CustomLicenseOption.java
@@ -1,0 +1,30 @@
+package com.liberty52.product.service.entity.license;
+
+import java.util.UUID;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "license_product_option")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CustomLicenseOption {
+	@Id
+	private String id = UUID.randomUUID().toString();
+
+	@OneToOne
+	@JoinColumn(name = "license_option_detail_id")
+	private LicenseOptionDetail licenseOptionDetail;
+
+	public void associate(LicenseOptionDetail licenseOptionDetail) {
+		this.licenseOptionDetail = licenseOptionDetail;
+		this.licenseOptionDetail.associate(this);
+	}
+}

--- a/src/main/java/com/liberty52/product/service/entity/license/CustomLicenseOption.java
+++ b/src/main/java/com/liberty52/product/service/entity/license/CustomLicenseOption.java
@@ -2,19 +2,21 @@ package com.liberty52.product.service.entity.license;
 
 import java.util.UUID;
 
+import com.liberty52.product.service.entity.CustomProduct;
+
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "license_product_option")
+@Table(name = "custom_license_option")
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class CustomLicenseOption {
 	@Id
 	private String id = UUID.randomUUID().toString();
@@ -23,8 +25,20 @@ public class CustomLicenseOption {
 	@JoinColumn(name = "license_option_detail_id")
 	private LicenseOptionDetail licenseOptionDetail;
 
+	@OneToOne(mappedBy = "customLicenseOption" , cascade = CascadeType.PERSIST)
+	private CustomProduct customProduct;
+
 	public void associate(LicenseOptionDetail licenseOptionDetail) {
 		this.licenseOptionDetail = licenseOptionDetail;
 		this.licenseOptionDetail.associate(this);
+	}
+
+	public void associate(CustomProduct customProduct) {
+		this.customProduct = customProduct;
+		this.customProduct.associateWithCustomLicenseOption(this);
+	}
+
+	public static CustomLicenseOption create(){
+		return new CustomLicenseOption();
 	}
 }

--- a/src/main/java/com/liberty52/product/service/entity/license/CustomLicenseOption.java
+++ b/src/main/java/com/liberty52/product/service/entity/license/CustomLicenseOption.java
@@ -4,7 +4,6 @@ import java.util.UUID;
 
 import com.liberty52.product.service.entity.CustomProduct;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -25,12 +24,11 @@ public class CustomLicenseOption {
 	@JoinColumn(name = "license_option_detail_id")
 	private LicenseOptionDetail licenseOptionDetail;
 
-	@OneToOne(mappedBy = "customLicenseOption" , cascade = CascadeType.PERSIST)
+	@OneToOne(mappedBy = "customLicenseOption")
 	private CustomProduct customProduct;
 
 	public void associate(LicenseOptionDetail licenseOptionDetail) {
 		this.licenseOptionDetail = licenseOptionDetail;
-		this.licenseOptionDetail.associate(this);
 	}
 
 	public void associate(CustomProduct customProduct) {

--- a/src/main/java/com/liberty52/product/service/entity/license/LicenseOption.java
+++ b/src/main/java/com/liberty52/product/service/entity/license/LicenseOption.java
@@ -28,7 +28,7 @@ public class LicenseOption {
 	@Id
 	private String id = UUID.randomUUID().toString();
 
-	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "product_id")
 	private Product product;
 

--- a/src/main/java/com/liberty52/product/service/entity/license/LicenseOptionDetail.java
+++ b/src/main/java/com/liberty52/product/service/entity/license/LicenseOptionDetail.java
@@ -29,18 +29,16 @@ public class LicenseOptionDetail {
 	@JoinColumn(name = "license_option_id")
 	private LicenseOption licenseOption;
 
-	@OneToOne(mappedBy = "licenseOptionDetail" , cascade = CascadeType.ALL)
-	private CustomLicenseOption customLicenseOption;
 	@Column(nullable = false)
-	String artName;
+	private String artName;
 	@Column(nullable = false)
-	String artistName;
+	private String artistName;
 	@Column(nullable = false)
-	Integer stock;
+	private Integer stock;
 	@Column(nullable = false)
-	Boolean onSale;
+	private Boolean onSale;
 	@Column(nullable = false)
-	String artUrl;
+	private String artUrl;
 	@Column(nullable = false)
 	private Integer price;
 	@Column(nullable = false)
@@ -70,10 +68,6 @@ public class LicenseOptionDetail {
 	public void associate(LicenseOption licenseOption) {
 		this.licenseOption = licenseOption;
 		this.licenseOption.addDetail(this);
-	}
-
-	public void associate(CustomLicenseOption customLicenseOption) {
-		this.customLicenseOption = customLicenseOption;
 	}
 
 	public void modifyLicenseOptionDetail(LicenseOptionDetailModifyDto dto) {

--- a/src/main/java/com/liberty52/product/service/entity/license/LicenseOptionDetail.java
+++ b/src/main/java/com/liberty52/product/service/entity/license/LicenseOptionDetail.java
@@ -76,15 +76,18 @@ public class LicenseOptionDetail {
 		this.customLicenseOption = customLicenseOption;
 	}
 
-	public void modifyLicenseOptionDetail(LicenseOptionDetailModifyDto dto, String artUrl) {
+	public void modifyLicenseOptionDetail(LicenseOptionDetailModifyDto dto) {
 		this.artName = dto.getArtName();
 		this.artistName = dto.getArtistName();
 		this.stock = dto.getStock();
 		this.onSale = dto.getOnSale();
 		this.price = dto.getPrice();
-		this.artUrl = artUrl;
 		this.startDate = dto.getStartDate();
 		this.endDate = dto.getEndDate();
+	}
+
+	public void modifyLicenseArtUrl(String artUrl) {
+		this.artUrl = artUrl;
 	}
 
 	public void updateOnSale() {

--- a/src/main/java/com/liberty52/product/service/entity/license/LicenseOptionDetail.java
+++ b/src/main/java/com/liberty52/product/service/entity/license/LicenseOptionDetail.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import com.liberty52.product.service.controller.dto.LicenseOptionDetailModifyDto;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -28,7 +29,7 @@ public class LicenseOptionDetail {
 	@JoinColumn(name = "license_option_id")
 	private LicenseOption licenseOption;
 
-	@OneToOne(mappedBy = "licenseOptionDetail")
+	@OneToOne(mappedBy = "licenseOptionDetail" , cascade = CascadeType.ALL)
 	private CustomLicenseOption customLicenseOption;
 	@Column(nullable = false)
 	String artName;

--- a/src/main/java/com/liberty52/product/service/entity/license/LicenseOptionDetail.java
+++ b/src/main/java/com/liberty52/product/service/entity/license/LicenseOptionDetail.java
@@ -8,7 +8,9 @@ import com.liberty52.product.service.controller.dto.LicenseOptionDetailModifyDto
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -23,7 +25,11 @@ public class LicenseOptionDetail {
 	@Id
 	private String id = UUID.randomUUID().toString();
 	@ManyToOne
+	@JoinColumn(name = "license_option_id")
 	private LicenseOption licenseOption;
+
+	@OneToOne(mappedBy = "licenseOptionDetail")
+	private CustomLicenseOption customLicenseOption;
 	@Column(nullable = false)
 	String artName;
 	@Column(nullable = false)
@@ -63,6 +69,10 @@ public class LicenseOptionDetail {
 	public void associate(LicenseOption licenseOption) {
 		this.licenseOption = licenseOption;
 		this.licenseOption.addDetail(this);
+	}
+
+	public void associate(CustomLicenseOption customLicenseOption) {
+		this.customLicenseOption = customLicenseOption;
 	}
 
 	public void modifyLicenseOptionDetail(LicenseOptionDetailModifyDto dto, String artUrl) {

--- a/src/main/java/com/liberty52/product/service/repository/CustomLicenseOptionRepository.java
+++ b/src/main/java/com/liberty52/product/service/repository/CustomLicenseOptionRepository.java
@@ -1,0 +1,9 @@
+package com.liberty52.product.service.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.liberty52.product.service.entity.license.CustomLicenseOption;
+
+public interface CustomLicenseOptionRepository extends JpaRepository<CustomLicenseOption, String> {
+
+}

--- a/src/test/java/com/liberty52/product/service/applicationservice/impl/OrderCreateServiceImplUnitTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/impl/OrderCreateServiceImplUnitTest.java
@@ -17,6 +17,7 @@ import com.liberty52.product.service.controller.dto.PaymentVBankResponseDto;
 import com.liberty52.product.service.entity.CustomProduct;
 import com.liberty52.product.service.entity.OptionDetail;
 import com.liberty52.product.service.entity.Product;
+import com.liberty52.product.service.entity.license.CustomLicenseOption;
 import com.liberty52.product.service.entity.license.LicenseOption;
 import com.liberty52.product.service.entity.license.LicenseOptionDetail;
 import com.liberty52.product.service.entity.payment.CardPayment;
@@ -56,6 +57,7 @@ class OrderCreateServiceImplUnitTest {
     @Mock private VBankRepository vBankRepository;
     @Mock private ThreadManager threadManager;
     @Mock private LicenseOptionDetailRepository licenseOptionDetailRepository;
+    @Mock private CustomLicenseOptionRepository customLicenseOptionRepository;
 
     private PaymentCardResponseDto executeCardPaymentOrders(String authId, List<String> options, int quantity) {
         return service.createCardPaymentOrders(
@@ -129,6 +131,14 @@ class OrderCreateServiceImplUnitTest {
             .willReturn(Optional.of(licenseOptionDetail));
 
         var authId = "user_id";
+
+        CustomProduct customProduct = MockFactory.createCustomProduct("", 1, authId, mockProduct);
+        given(customProductRepository.save(any())).willReturn(customProduct);
+
+        CustomLicenseOption customLicenseOption = MockFactory.createCustomLicenseOption(customProduct,licenseOptionDetail);
+        given(customLicenseOptionRepository.save(any())).willReturn(customLicenseOption);
+
+
         var order = MockFactory.createOrder(authId);
         given(ordersRepository.save(any())).willReturn(order);
 

--- a/src/test/java/com/liberty52/product/service/applicationservice/impl/OrderCreateServiceImplUnitTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/impl/OrderCreateServiceImplUnitTest.java
@@ -16,6 +16,9 @@ import com.liberty52.product.service.controller.dto.PaymentCardResponseDto;
 import com.liberty52.product.service.controller.dto.PaymentVBankResponseDto;
 import com.liberty52.product.service.entity.CustomProduct;
 import com.liberty52.product.service.entity.OptionDetail;
+import com.liberty52.product.service.entity.Product;
+import com.liberty52.product.service.entity.license.LicenseOption;
+import com.liberty52.product.service.entity.license.LicenseOptionDetail;
 import com.liberty52.product.service.entity.payment.CardPayment;
 import com.liberty52.product.service.entity.payment.Payment;
 import com.liberty52.product.service.repository.*;
@@ -27,6 +30,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -38,7 +42,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class OrderCreateServiceImplUnitTest {
+class OrderCreateServiceImplUnitTest {
 
     @InjectMocks private OrderCreateServiceImpl service;
     @Mock private S3UploaderApi s3UploaderApi;
@@ -51,6 +55,7 @@ public class OrderCreateServiceImplUnitTest {
     @Mock private ConfirmPaymentMapRepository confirmPaymentMapRepository;
     @Mock private VBankRepository vBankRepository;
     @Mock private ThreadManager threadManager;
+    @Mock private LicenseOptionDetailRepository licenseOptionDetailRepository;
 
     private PaymentCardResponseDto executeCardPaymentOrders(String authId, List<String> options, int quantity) {
         return service.createCardPaymentOrders(
@@ -107,6 +112,36 @@ public class OrderCreateServiceImplUnitTest {
         assertEquals(order.getOrderNum(), result.getOrderNum());
         assertEquals(order.getAmount(), result.getAmount());
     }
+
+    @Test
+    @DisplayName("라이선스 상품을 카드 주문을 요청하여 주문을 생성한다")
+    void createCardPaymentOrderForLicenseProduct() {
+        //given
+        Product mockProduct = mock(Product.class);
+        given(mockProduct.isCustom()).willReturn(false);
+        given(productRepository.findByName(anyString())).willReturn(Optional.of(mockProduct));
+
+        LicenseOption licenseOption = MockFactory.createLicenseOption("licenseOption");
+        LicenseOptionDetail licenseOptionDetail = MockFactory.createLicenseOptionDetail("licenseOptionDetail",
+            "testArtist", 10, true, "testUrl", 10000, LocalDate.now(), LocalDate.now().plusDays(3), licenseOption);
+
+        given(licenseOptionDetailRepository.findById(any()))
+            .willReturn(Optional.of(licenseOptionDetail));
+
+        var authId = "user_id";
+        var order = MockFactory.createOrder(authId);
+        given(ordersRepository.save(any())).willReturn(order);
+
+        // when
+        var result = executeCardPaymentOrders(authId, List.of(licenseOptionDetail.getId()), 1);
+
+        // then
+        assertNotNull(result);
+        assertEquals(order.getId(), result.getMerchantId());
+        assertEquals(order.getOrderNum(), result.getOrderNum());
+        assertEquals(order.getAmount(), result.getAmount());
+    }
+
 
     @Test
     @DisplayName("존재하지 않는 상품을 카드결제 주문할 경우 예외가 발생한다")

--- a/src/test/java/com/liberty52/product/service/applicationservice/mock/LicenseOptionDetailModifyMockTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/mock/LicenseOptionDetailModifyMockTest.java
@@ -55,7 +55,8 @@ class LicenseOptionDetailModifyMockTest {
 			artImageFile);
 
 		// Then
-		verify(mockLicenseOptionDetail, times(1)).modifyLicenseOptionDetail(dto, "modifiedArtUrl");
+		verify(mockLicenseOptionDetail, times(1)).modifyLicenseOptionDetail(dto);
+		verify(mockLicenseOptionDetail, times(1)).modifyLicenseArtUrl("modifiedArtUrl");
 	}
 
 	@Test
@@ -72,27 +73,6 @@ class LicenseOptionDetailModifyMockTest {
 
 		assertThrows(
 			ResourceNotFoundException.class,
-			() -> licenseOptionDetailModifyService.modifyLicenseOptionDetailByAdmin(ADMIN, licenseOptionDetailId, dto,
-				artImageFile));
-	}
-
-	@Test
-	void modifyLicenseOptionDetailByAdmin_When_ArtImageFileIsNullTest() {
-		// Given
-		String licenseOptionDetailId = "testLicenseOptionDetailId";
-		LocalDate startDate = LocalDate.of(2023, 1, 1);
-		LocalDate endDate = startDate.plusDays(10);
-		LicenseOptionDetailModifyDto dto = new LicenseOptionDetailModifyDto("ArtName", "ArtistName", 10, 1000, true,
-			startDate, endDate);
-		MultipartFile artImageFile = null;
-
-		LicenseOptionDetail mockLicenseOptionDetail = mock(LicenseOptionDetail.class);
-		when(licenseOptionDetailRepository.findById(licenseOptionDetailId)).thenReturn(
-			Optional.of(mockLicenseOptionDetail));
-
-		// When
-		// Then
-		assertThrows(BadRequestException.class,
 			() -> licenseOptionDetailModifyService.modifyLicenseOptionDetailByAdmin(ADMIN, licenseOptionDetailId, dto,
 				artImageFile));
 	}

--- a/src/test/java/com/liberty52/product/service/utils/MockFactory.java
+++ b/src/test/java/com/liberty52/product/service/utils/MockFactory.java
@@ -5,6 +5,8 @@ import com.liberty52.product.service.controller.dto.OrderRetrieveProductResponse
 import com.liberty52.product.service.controller.dto.OrdersRetrieveResponse;
 import com.liberty52.product.service.controller.dto.ReviewRetrieveResponse;
 import com.liberty52.product.service.entity.*;
+import com.liberty52.product.service.entity.license.LicenseOption;
+import com.liberty52.product.service.entity.license.LicenseOptionDetail;
 import com.liberty52.product.service.entity.payment.BankType;
 import com.liberty52.product.service.entity.payment.VBank;
 
@@ -228,5 +230,15 @@ public class MockFactory {
         return option;
     }
 
+    public static LicenseOption createLicenseOption(String name) {
+        return LicenseOption.create(name);
+    }
 
+    public static LicenseOptionDetail createLicenseOptionDetail(String artName, String artistName, Integer stock, Boolean onSale,
+        String artUrl, Integer price, LocalDate startDate, LocalDate endDate, LicenseOption licenseOption) {
+        LicenseOptionDetail licenseOptionDetail = LicenseOptionDetail.create(artName, artistName,
+            stock, onSale, artUrl, price, startDate, endDate);
+        licenseOptionDetail.associate(licenseOption);
+        return licenseOptionDetail;
+    }
 }

--- a/src/test/java/com/liberty52/product/service/utils/MockFactory.java
+++ b/src/test/java/com/liberty52/product/service/utils/MockFactory.java
@@ -184,7 +184,8 @@ public class MockFactory {
                 ,MOCK_PRICE,
                 MOCK_PRODUCT_REPRESENT_URL,
                 false,
-                null);
+                null,
+                true);
     }
 
     public static OrderDetailRetrieveResponse createMockOrderDetailRetrieveResponse(){

--- a/src/test/java/com/liberty52/product/service/utils/MockFactory.java
+++ b/src/test/java/com/liberty52/product/service/utils/MockFactory.java
@@ -5,6 +5,7 @@ import com.liberty52.product.service.controller.dto.OrderRetrieveProductResponse
 import com.liberty52.product.service.controller.dto.OrdersRetrieveResponse;
 import com.liberty52.product.service.controller.dto.ReviewRetrieveResponse;
 import com.liberty52.product.service.entity.*;
+import com.liberty52.product.service.entity.license.CustomLicenseOption;
 import com.liberty52.product.service.entity.license.LicenseOption;
 import com.liberty52.product.service.entity.license.LicenseOptionDetail;
 import com.liberty52.product.service.entity.payment.BankType;
@@ -241,5 +242,12 @@ public class MockFactory {
             stock, onSale, artUrl, price, startDate, endDate);
         licenseOptionDetail.associate(licenseOption);
         return licenseOptionDetail;
+    }
+
+    public static CustomLicenseOption createCustomLicenseOption(CustomProduct customProduct, LicenseOptionDetail licenseOptionDetail) {
+		CustomLicenseOption customLicenseOption = CustomLicenseOption.create();
+		customLicenseOption.associate(customProduct);
+		customLicenseOption.associate(licenseOptionDetail);
+		return customLicenseOption;
     }
 }


### PR DESCRIPTION
Resolve #351 
### 작업
- 라이선스 상품 주문 생성
- 주문 목록 조회 시 isCustom필드 추가
### 이슈 처리
- 가상계좌 입력시 은행 종류 제한 해제
- 라이선스 옵션 상세 수정 시 이미지만 따로 수정 가능

### 테스트 
![image](https://github.com/Liberty52/product/assets/55132026/0c705f74-13b1-4b39-b81f-92d0fa8be3fe)
![image](https://github.com/Liberty52/product/assets/55132026/328df4aa-379c-469c-9057-335589c57a12)


***
### 이슈
이슈 처리와 작업 PR를 따로 나눴어야 했는데 죄송합니다. 다음에는 꼭 분리하겠습니다!