### PR TITLE
매출액, 판매량 동적 조회

### DIFF
--- a/src/main/java/com/liberty52/product/service/applicationservice/SalesRetrieveService.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/SalesRetrieveService.java
@@ -1,0 +1,8 @@
+package com.liberty52.product.service.applicationservice;
+
+import com.liberty52.product.service.controller.dto.SalesRequestDto;
+import com.liberty52.product.service.controller.dto.SalesResponseDto;
+
+public interface SalesRetrieveService {
+    public SalesResponseDto retrieveSales(String role, SalesRequestDto salesRequestDto);
+}

--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/SalesRetrieveServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/SalesRetrieveServiceImpl.java
@@ -1,0 +1,45 @@
+package com.liberty52.product.service.applicationservice.impl;
+
+import com.liberty52.product.global.util.Validator;
+import com.liberty52.product.service.applicationservice.SalesRetrieveService;
+import com.liberty52.product.service.controller.dto.SalesRequestDto;
+import com.liberty52.product.service.controller.dto.SalesResponseDto;
+import com.liberty52.product.service.entity.*;
+import com.liberty52.product.service.repository.OrderQueryDslRepository;
+import com.liberty52.product.service.repository.OrdersRepository;
+import com.querydsl.core.Tuple;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class SalesRetrieveServiceImpl implements SalesRetrieveService {
+    private final OrderQueryDslRepository orderQueryDslRepository;
+    final OrdersRepository ordersRepository;
+    @Override
+    public SalesResponseDto retrieveSales(String role, SalesRequestDto salesRequestDto) {
+        Validator.isAdmin(role);
+        List<Tuple> result = orderQueryDslRepository.retrieveByConditions(salesRequestDto);
+        if(result.isEmpty()) return SalesResponseDto.builder()
+                        .salesMoney(0L).salesQuantity(0L).build();
+
+        Long totalSalesMoney = result.stream()
+                .map(tuple -> tuple.get(0, Long.class))
+                .filter(Objects::nonNull)
+                .mapToLong(Long::longValue)
+                .sum();
+
+        Long totalSalesQuantity = result.stream()
+                .map(tuple -> tuple.get(1, Long.class))
+                .filter(Objects::nonNull)
+                .mapToLong(Long::longValue)
+                .sum();
+
+        return SalesResponseDto.builder()
+                .salesMoney(totalSalesMoney).salesQuantity(totalSalesQuantity).build();
+
+    }
+}

--- a/src/main/java/com/liberty52/product/service/controller/SalesAdminController.java
+++ b/src/main/java/com/liberty52/product/service/controller/SalesAdminController.java
@@ -1,0 +1,28 @@
+package com.liberty52.product.service.controller;
+
+
+import com.liberty52.product.service.applicationservice.SalesRetrieveService;
+import com.liberty52.product.service.controller.dto.SalesRequestDto;
+import com.liberty52.product.service.controller.dto.SalesResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "매출", description = "매출 관련 API를 제공합니다")
+@RestController
+@RequiredArgsConstructor
+public class SalesAdminController {
+
+    private final SalesRetrieveService salesRetrieveService;
+    @Operation(summary = "매출 조회", description = "조건에 맞는 매출과 판매량을 조회합니다.")
+    @GetMapping("admin/sales")
+    public ResponseEntity<SalesResponseDto> retrieveSalesByAdmin(@RequestHeader("LB-Role") String role, @RequestBody SalesRequestDto salesRequestDto){
+        return ResponseEntity.status(HttpStatus.OK).body(salesRetrieveService.retrieveSales(role, salesRequestDto));
+    }
+}

--- a/src/main/java/com/liberty52/product/service/controller/dto/SalesRequestDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/SalesRequestDto.java
@@ -1,12 +1,13 @@
 package com.liberty52.product.service.controller.dto;
 
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 import java.time.LocalDate;
 
 @Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SalesRequestDto {
     String productName;
     LocalDate startDate;

--- a/src/main/java/com/liberty52/product/service/controller/dto/SalesRequestDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/SalesRequestDto.java
@@ -1,0 +1,14 @@
+package com.liberty52.product.service.controller.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class SalesRequestDto {
+    String productName;
+    LocalDate startDate;
+    LocalDate endDate;
+}

--- a/src/main/java/com/liberty52/product/service/controller/dto/SalesResponseDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/SalesResponseDto.java
@@ -1,0 +1,11 @@
+package com.liberty52.product.service.controller.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SalesResponseDto {
+    private Long salesMoney;
+    private Long salesQuantity;
+}

--- a/src/main/java/com/liberty52/product/service/controller/dto/SalesResponseDto.java
+++ b/src/main/java/com/liberty52/product/service/controller/dto/SalesResponseDto.java
@@ -1,11 +1,18 @@
 package com.liberty52.product.service.controller.dto;
 
-import lombok.Builder;
-import lombok.Getter;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.*;
 
 @Getter
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SalesResponseDto {
     private Long salesMoney;
     private Long salesQuantity;
+
+    @Builder
+    public SalesResponseDto(Long salesMoney, Long salesQuantity) {
+        this.salesMoney = salesMoney;
+        this.salesQuantity = salesQuantity;
+    }
+
 }

--- a/src/main/java/com/liberty52/product/service/repository/OrderQueryDslRepository.java
+++ b/src/main/java/com/liberty52/product/service/repository/OrderQueryDslRepository.java
@@ -1,7 +1,9 @@
 package com.liberty52.product.service.repository;
 
+import com.liberty52.product.service.controller.dto.SalesRequestDto;
 import com.liberty52.product.service.entity.OrderStatus;
 import com.liberty52.product.service.entity.Orders;
+import com.querydsl.core.Tuple;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -31,4 +33,5 @@ public interface OrderQueryDslRepository {
 
     OrderQueryDslRepositoryImpl.PageInfo getCanceledOrdersPageInfo(Pageable pageable, OrderStatus... statuses);
 
+    List<Tuple> retrieveByConditions(SalesRequestDto salesRequestDto);
 }

--- a/src/test/java/com/liberty52/product/service/applicationservice/SalesRetrieveServiceImplTest.java
+++ b/src/test/java/com/liberty52/product/service/applicationservice/SalesRetrieveServiceImplTest.java
@@ -1,0 +1,87 @@
+package com.liberty52.product.service.applicationservice;
+
+import com.liberty52.product.service.controller.dto.SalesRequestDto;
+import com.liberty52.product.service.controller.dto.SalesResponseDto;
+import com.liberty52.product.service.entity.CustomProduct;
+import com.liberty52.product.service.entity.OrderStatus;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.liberty52.product.global.constants.RoleConstants.ADMIN;
+
+@SpringBootTest
+public class SalesRetrieveServiceImplTest {
+    @Autowired
+    private SalesRetrieveService salesRetrieveService;
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    void 매출조회_시작일(){
+        // Given
+        SalesRequestDto requestDto = SalesRequestDto.builder().startDate(LocalDate.parse("2099-12-31")).build();
+        // When
+        SalesResponseDto responseDto = salesRetrieveService.retrieveSales(ADMIN,requestDto);
+        // Then
+        Assertions.assertEquals(0, responseDto.getSalesQuantity());
+    }
+
+    @Test
+    void 매출조회_조건없음(){
+        // Given
+        SalesRequestDto requestDto = SalesRequestDto.builder().build();
+        // When
+        SalesResponseDto responseDto = salesRetrieveService.retrieveSales(ADMIN,requestDto);
+        TypedQuery<CustomProduct> query = entityManager.createQuery(
+                "SELECT c FROM CustomProduct c " +
+                        "JOIN FETCH c.orders " +
+                        "WHERE c.orders.orderStatus NOT IN (:param1, :param2, :param3)",
+                CustomProduct.class);
+
+                query
+                .setParameter("param1", OrderStatus.CANCEL_REQUESTED)
+                .setParameter("param2", OrderStatus.CANCELED)
+                .setParameter("param3", OrderStatus.REFUND);
+                List<CustomProduct> found = query.getResultList();
+        //Then
+        Assertions.assertEquals(found.size(), responseDto.getSalesQuantity());
+    }
+
+    @Test
+    void 매출조회_제품명(){
+        // Given
+        String testProductName = "Liberty 52_Frame";
+        SalesRequestDto requestDto = SalesRequestDto.builder().productName(testProductName).build();
+        // When
+        SalesResponseDto responseDto = salesRetrieveService.retrieveSales(ADMIN,requestDto);
+        TypedQuery<CustomProduct> query = entityManager.createQuery(
+                "SELECT c FROM CustomProduct c " +
+                        "JOIN FETCH c.product p " +
+                        "JOIN FETCH c.orders " +
+                        "WHERE c.orders.orderStatus NOT IN (:param1, :param2, :param3) " +
+                        "AND p.name = :productName",
+                CustomProduct.class);
+
+                query
+                .setParameter("param1", OrderStatus.CANCEL_REQUESTED)
+                .setParameter("param2", OrderStatus.CANCELED)
+                .setParameter("param3", OrderStatus.REFUND)
+                .setParameter("productName", testProductName);
+        List<CustomProduct> found = query.getResultList();
+
+        Long foundSalesMoney = 0L;
+        for (CustomProduct customProduct : found) {
+            foundSalesMoney += customProduct.getOrders().getAmount();
+        }
+        // Then
+        Assertions.assertEquals(found.size(), responseDto.getSalesQuantity());
+        Assertions.assertEquals(foundSalesMoney, responseDto.getSalesMoney());
+    }
+}


### PR DESCRIPTION
## 스프린트 넘버  : 9
### 백로그 이름 : 매출 관리


***
### 작업
조건에 따라 매출액과 판매량을 동적 조회 (현재 적용된 조건은 기간, 제품명 -> 향후 다른 조건들 추가 가능)

**API**
```
GET /admin/sales
Request Header
{
  "LB-Role" : accessToken,
}
Request Body
{
  "startDate" : LocalDate (required = false)
  "endDate" : LocalDate (required = false)
  "productName" : String (required = false)
}
* 요청 예시
전체 기간에 대한 조회 : body없이 요청
상품별 조회 : productName만 명시해 요청
특정 기간 이후의 조회 : startDate만 명시해 요청
특정 기간 까지의 조회 : endDate만 명시해 요청
특정 기간 사이의 조회 : startDate, endDate 명시해 요청
...
Response Status : 200(성공), 400(잘못된 요청데이터 양식), 401(토큰 없음 - 비 로그인 상태 등), 403(권한 없음 - 관리자 아님 등)
Response Body
{
 salesMoney : 매출액 (Long)
 salesQuantity : 판매량 (Long)
}
``` 

**CODE** 
QueryDSL 사용

***
### 테스트 결과
![image](https://github.com/Liberty52/product/assets/96376539/71ceab8d-c768-43d5-b4a8-67aebe117308)

***
### 이슈
none