### PR TITLE
상품, 커스텀 상품 삭제관련 참조관계 설정 조정

### DIFF
--- a/src/main/java/com/liberty52/product/service/applicationservice/impl/ProductRemoveServiceImpl.java
+++ b/src/main/java/com/liberty52/product/service/applicationservice/impl/ProductRemoveServiceImpl.java
@@ -5,6 +5,8 @@ import com.liberty52.product.global.exception.external.notfound.ResourceNotFound
 import com.liberty52.product.global.util.Validator;
 import com.liberty52.product.service.applicationservice.ProductRemoveService;
 import com.liberty52.product.service.entity.Product;
+import com.liberty52.product.service.repository.CustomProductRepository;
+import com.liberty52.product.service.repository.ProductOptionRepository;
 import com.liberty52.product.service.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class ProductRemoveServiceImpl implements ProductRemoveService {
     private final ProductRepository productRepository;
+    private final ProductOptionRepository productOptionRepository;
+    private final CustomProductRepository customProductRepository;
     private final S3UploaderApi s3Uploader;
 
     @Override
@@ -24,6 +28,7 @@ public class ProductRemoveServiceImpl implements ProductRemoveService {
                 .orElseThrow(() -> new ResourceNotFoundException("Product", "ID", productId));
         String productImageUrl = product.getPictureUrl();
         if(productImageUrl != null) s3Uploader.delete(productImageUrl);
+        customProductRepository.deleteByProduct(product);
         productRepository.delete(product);
     }
 }

--- a/src/main/java/com/liberty52/product/service/entity/Product.java
+++ b/src/main/java/com/liberty52/product/service/entity/Product.java
@@ -32,10 +32,10 @@ public class Product {
     @Column(nullable = false)
     private boolean isCustom;
 
-    @OneToMany(mappedBy = "product")
+    @OneToMany(mappedBy = "product", cascade = CascadeType.REMOVE)
     private List<ProductOption> productOptions = new ArrayList<>();
 
-    @OneToOne(mappedBy = "product", cascade = CascadeType.PERSIST)
+    @OneToOne(mappedBy = "product", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private LicenseOption licenseOption;
 
     private String pictureUrl;

--- a/src/main/java/com/liberty52/product/service/entity/ProductOption.java
+++ b/src/main/java/com/liberty52/product/service/entity/ProductOption.java
@@ -31,7 +31,7 @@ public class ProductOption {
     @Column(nullable = false)
     private boolean onSale;
 
-    @OneToMany(fetch = FetchType.EAGER, mappedBy = "productOption")
+    @OneToMany(fetch = FetchType.EAGER, mappedBy = "productOption", cascade = CascadeType.REMOVE)
     private List<OptionDetail> optionDetails = new ArrayList<>();
 
     @Builder

--- a/src/main/java/com/liberty52/product/service/repository/CustomProductRepository.java
+++ b/src/main/java/com/liberty52/product/service/repository/CustomProductRepository.java
@@ -1,8 +1,14 @@
 package com.liberty52.product.service.repository;
 
 import com.liberty52.product.service.entity.CustomProduct;
+import com.liberty52.product.service.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface CustomProductRepository extends JpaRepository<CustomProduct, String> {
 
+    void deleteByProduct(Product product);
+
+    List<CustomProduct> findByProduct(Product product);
 }


### PR DESCRIPTION
***
### 작업
1. 상품을 삭제하면  커스텀 상품과 참조관계로 인해 삭제가 되지 않음 -> 양방향 관계설정으로 관리하려 했으나 관계 설정시 다른 코드 20곳 이상에서 오류가 발생 -> 삭제시 먼저 커스텀 상품을 삭제하고 상품 삭제하도록 변경
2.  상품을 삭제하면 상품옵션과 참조관계로 인해 삭제가 되지 않음 -> 동일한 문제 -> 기존에 양방향 관계 매핑 되어 있었어서 cascadetype.REMOVE 임시방편으로 추가
3.  상품을 삭제 -> 상품옵션을 먼저 삭제해야함 -> 옵션디테일과 참조관계로 인해 삭제가 되지 않음 -> 동일한 방법으로 해결
4. 옵션디테일 -> 커스텀 프로덕트 옵션과의 별도의 참조관계를 고려한 설정이 없어보여 마찬가지로 문제 발생이 예상되나 일단 두었음 
***
### 이슈
일단 로컬환경에서 눈에 보이는 문제들만 임시방편으로 막았습니다. 양방향 매핑시 참조 관계를 명확히 설정하지 않았거나 별도의 삭제 로직이 없을 시 이렇게 꼬리에 꼬리를 무는 형태로 또 문제가 분명 터질거 같습니다. 제가 다 바꾸기엔 범위가 너무 넓고 어떤 로직에 손상을 줄지 알 수 없어 당장 눈에 보이는 오류만 막았으니 나중에 시간적 여유가 있으면 이것에 대해 논의하면 좋을거 같습니다