### PR TITLE
라이선스 상품 주문 관련 로직 변경

### DIFF
--- a/liberty-main-service/src/main/java/com/liberty52/main/service/applicationservice/LicenseOptionDetailStockManageService.java
+++ b/liberty-main-service/src/main/java/com/liberty52/main/service/applicationservice/LicenseOptionDetailStockManageService.java
@@ -1,0 +1,13 @@
+package com.liberty52.main.service.applicationservice;
+
+import com.liberty52.main.global.util.Result;
+import com.liberty52.main.service.entity.license.LicenseOptionDetail;
+
+public interface LicenseOptionDetailStockManageService {
+
+    Result<LicenseOptionDetail> decrement(String optionDetailId, int quantity);
+
+    Result<LicenseOptionDetail> increment(String optionDetailId, int quantity);
+
+    Result<LicenseOptionDetail> rollback(String optionDetailId, int quantity);
+}

--- a/liberty-main-service/src/main/java/com/liberty52/main/service/applicationservice/OptionDetailMultipleStockManageService.java
+++ b/liberty-main-service/src/main/java/com/liberty52/main/service/applicationservice/OptionDetailMultipleStockManageService.java
@@ -2,9 +2,12 @@ package com.liberty52.main.service.applicationservice;
 
 import com.liberty52.main.global.util.Result;
 import com.liberty52.main.service.entity.OptionDetail;
+import com.liberty52.main.service.entity.license.LicenseOptionDetail;
 
 import java.util.List;
 
 public interface OptionDetailMultipleStockManageService {
     Result<List<OptionDetail>> decrement(List<String> optionDetailIds, int quantity);
+
+    Result<List<LicenseOptionDetail>> decrementLicense(List<String> licenseOptionDetailIds, int quantity);
 }

--- a/liberty-main-service/src/main/java/com/liberty52/main/service/applicationservice/impl/LicenseOptionDetailStockManageServiceImpl.java
+++ b/liberty-main-service/src/main/java/com/liberty52/main/service/applicationservice/impl/LicenseOptionDetailStockManageServiceImpl.java
@@ -1,0 +1,64 @@
+package com.liberty52.main.service.applicationservice.impl;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.liberty52.main.global.annotation.DistributedLock;
+import com.liberty52.main.global.exception.external.badrequest.BadRequestException;
+import com.liberty52.main.global.exception.external.notfound.ResourceNotFoundException;
+import com.liberty52.main.global.util.Result;
+import com.liberty52.main.service.applicationservice.LicenseOptionDetailStockManageService;
+import com.liberty52.main.service.entity.license.LicenseOptionDetail;
+import com.liberty52.main.service.repository.LicenseOptionDetailRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LicenseOptionDetailStockManageServiceImpl implements LicenseOptionDetailStockManageService {
+	private final LicenseOptionDetailRepository licenseOptionDetailRepository;
+
+	@Override
+	@Transactional(propagation = Propagation.REQUIRED)
+	@DistributedLock(key = "#licenseOptionDetailId")
+	public Result<LicenseOptionDetail> decrement(String licenseOptionDetailId, int quantity) {
+		return Result.runCatching(() -> {
+			var licenseOptionDetail = this.findById(licenseOptionDetailId);
+			licenseOptionDetail.sold(quantity)
+				.orElseThrow(() -> new BadRequestException(licenseOptionDetail.getArtName() + " 옵션의 재고량이 부족하여 구매할 수 없습니다."));
+			return licenseOptionDetail;
+		});
+	}
+
+	@Override
+	@Transactional(propagation = Propagation.REQUIRED)
+	@DistributedLock(key = "#licenseOptionDetailId")
+	public Result<LicenseOptionDetail> increment(String licenseOptionDetailId, int quantity) {
+		return Result.runCatching(() -> {
+			var licenseOptionDetail = this.findById(licenseOptionDetailId);
+			licenseOptionDetail.rollbackStock(quantity);
+			return licenseOptionDetail;
+		});
+	}
+
+	@Override
+	@Transactional(propagation = Propagation.REQUIRED)
+	@DistributedLock(key = "#licenseOptionDetailId")
+	public Result<LicenseOptionDetail> rollback(String licenseOptionDetailId, int quantity) {
+		return Result.runCatching(() -> {
+			var licenseOptionDetail = this.findById(licenseOptionDetailId);
+			if (licenseOptionDetail.getStock() > 0) {
+				licenseOptionDetail.rollbackStock(quantity);
+			}
+			return licenseOptionDetail;
+		});
+	}
+
+	private LicenseOptionDetail findById(String id) {
+		return licenseOptionDetailRepository.findById(id)
+			.orElseThrow(() -> new ResourceNotFoundException("license option detail", "id", id));
+	}
+}

--- a/liberty-main-service/src/main/java/com/liberty52/main/service/applicationservice/impl/OptionDetailMultipleStockManageServiceImpl.java
+++ b/liberty-main-service/src/main/java/com/liberty52/main/service/applicationservice/impl/OptionDetailMultipleStockManageServiceImpl.java
@@ -1,6 +1,7 @@
 package com.liberty52.main.service.applicationservice.impl;
 
 import com.liberty52.main.global.util.Result;
+import com.liberty52.main.service.applicationservice.LicenseOptionDetailStockManageService;
 import com.liberty52.main.service.applicationservice.OptionDetailMultipleStockManageService;
 import com.liberty52.main.service.applicationservice.OptionDetailStockManageService;
 import com.liberty52.main.service.entity.OptionDetail;
@@ -19,7 +20,7 @@ import java.util.List;
 public class OptionDetailMultipleStockManageServiceImpl implements OptionDetailMultipleStockManageService {
 
     private final OptionDetailStockManageService optionDetailStockManageService;
-    private final LicenseOptionDetailStockManageServiceImpl licenseOptionDetailStockManageService;
+    private final LicenseOptionDetailStockManageService licenseOptionDetailStockManageService;
 
 
     /**

--- a/liberty-main-service/src/main/java/com/liberty52/main/service/applicationservice/impl/OptionDetailMultipleStockManageServiceImpl.java
+++ b/liberty-main-service/src/main/java/com/liberty52/main/service/applicationservice/impl/OptionDetailMultipleStockManageServiceImpl.java
@@ -4,6 +4,8 @@ import com.liberty52.main.global.util.Result;
 import com.liberty52.main.service.applicationservice.OptionDetailMultipleStockManageService;
 import com.liberty52.main.service.applicationservice.OptionDetailStockManageService;
 import com.liberty52.main.service.entity.OptionDetail;
+import com.liberty52.main.service.entity.license.LicenseOptionDetail;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -16,7 +18,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class OptionDetailMultipleStockManageServiceImpl implements OptionDetailMultipleStockManageService {
 
-    private final OptionDetailStockManageService stockManageService;
+    private final OptionDetailStockManageService optionDetailStockManageService;
+    private final LicenseOptionDetailStockManageServiceImpl licenseOptionDetailStockManageService;
+
 
     /**
      * 해당 메소드는 DistributedLockTransaction을 통해 각각의 옵션 디테일 별로 트랜잭션이 생성됨에 따라
@@ -33,15 +37,36 @@ public class OptionDetailMultipleStockManageServiceImpl implements OptionDetailM
             try {
                 return optionDetailIds.stream()
                         .map(it -> {
-                            var optionDetail = stockManageService.decrement(it, quantity).getOrThrow();
+                            var optionDetail = optionDetailStockManageService.decrement(it, quantity).getOrThrow();
                             rollbackList.add(optionDetail);
                             return optionDetail;
                         })
                         .toList();
             } catch (Exception e) {
-                rollbackList.forEach(it -> stockManageService.rollback(it.getId(), quantity).getOrThrow());
+                rollbackList.forEach(it -> optionDetailStockManageService.rollback(it.getId(), quantity).getOrThrow());
                 throw e;
             }
         });
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRED)
+    public Result<List<LicenseOptionDetail>> decrementLicense(List<String> licenseOptionDetailIds, int quantity) {
+        return Result.runCatching(() -> {
+            List<LicenseOptionDetail> rollbackList = new ArrayList<>();
+            try {
+                return licenseOptionDetailIds.stream()
+                        .map(it -> {
+                            var licenseOptionDetail = licenseOptionDetailStockManageService.decrement(it, quantity).getOrThrow();
+                            rollbackList.add(licenseOptionDetail);
+                            return licenseOptionDetail;
+                        })
+                        .toList();
+            } catch (Exception e) {
+                rollbackList.forEach(it -> licenseOptionDetailStockManageService.rollback(it.getId(), quantity).getOrThrow());
+                throw e;
+            }
+        });
+
     }
 }

--- a/liberty-main-service/src/main/java/com/liberty52/main/service/applicationservice/impl/OrderCreateServiceImpl.java
+++ b/liberty-main-service/src/main/java/com/liberty52/main/service/applicationservice/impl/OrderCreateServiceImpl.java
@@ -206,7 +206,6 @@ public class OrderCreateServiceImpl implements OrderCreateService {
     }
 
     private List<CustomProduct> getCustomProducts(String authId, OrderCreateRequestDto dto) {
-        Product product = getProduct(dto);
         return dto.getCustomProductIdList().stream()
                 .map(customProductId -> customProductRepository.findById(customProductId)
                         .orElseThrow(() -> new ResourceNotFoundException("CUSTOM_PRODUCT", "ID", customProductId)))
@@ -215,7 +214,7 @@ public class OrderCreateServiceImpl implements OrderCreateService {
                         throw new NotYourCustomProductException(authId);
                     }
 
-                    if (!product.isCustom()){
+                    if (!customProduct.getProduct().isCustom()){
                         String licenseOptionId = customProduct.getCustomLicenseOption().getLicenseOptionDetail().getId();
                         optionDetailMultipleStockManageService.decrementLicense(List.of(licenseOptionId), customProduct.getQuantity()).getOrThrow();
                     }

--- a/liberty-main-service/src/main/java/com/liberty52/main/service/applicationservice/impl/OrderCreateServiceImpl.java
+++ b/liberty-main-service/src/main/java/com/liberty52/main/service/applicationservice/impl/OrderCreateServiceImpl.java
@@ -43,6 +43,8 @@ public class OrderCreateServiceImpl implements OrderCreateService {
 
     private static final String RESOURCE_NAME_PRODUCT = "Product";
     private static final String PARAM_NAME_PRODUCT_NAME = "name";
+    private static final String RESOURCE_NAME_LICENSE_OPTION_DETAIL = "LicenseOptionDetail";
+    private static final String PARAM_NAME_LICENSE_OPTION_DETAIL_NAME = "licenseName";
     private static final String RESOURCE_NAME_OPTION_DETAIL = "OptionDetail";
     private static final String PARAM_NAME_OPTION_DETAIL_NAME = "name";
     private final S3UploaderApi s3Uploader;
@@ -149,12 +151,9 @@ public class OrderCreateServiceImpl implements OrderCreateService {
         Orders order = ordersRepository.save(Orders.create(authId, orderDestination));
 
         if (!product.isCustom()) {
-            LicenseOptionDetail licenseOptionDetail = licenseOptionDetailRepository.findById(
-                            dto.getProductDto().getOptionDetailIds().get(0))
-                    .orElseThrow(() -> new ResourceNotFoundException("LICENSE_OPTION_DETAIL", "ID",
-                            dto.getProductDto().getOptionDetailIds().get(0)));
+            List<LicenseOptionDetail> licenseOptionDetails = this.getLicenseOptionDetail(dto);
             CustomProduct customProduct = this.createLicenseCustomProduct(authId, dto, product, order);
-            this.createCustomLicenseOption(customProduct, licenseOptionDetail);
+            this.createCustomLicenseOption(customProduct, licenseOptionDetails.get(0));
             customProductRepository.save(customProduct);
         } else {
             List<OptionDetail> optionDetails = this.getOptionDetails(dto);
@@ -186,12 +185,23 @@ public class OrderCreateServiceImpl implements OrderCreateService {
                 .orElseThrow(() -> new ResourceNotFoundException(RESOURCE_NAME_PRODUCT, PARAM_NAME_PRODUCT_NAME, dto.getProductDto().getProductName()));
     }
 
+    private List<LicenseOptionDetail> getLicenseOptionDetail(OrderCreateRequestDto dto) {
+        List<String> licenseOptionDetailId = dto.getProductDto().getOptionDetailIds().stream()
+            .map(it -> licenseOptionDetailRepository.findById(it)
+                .orElseThrow(() -> new ResourceNotFoundException(RESOURCE_NAME_LICENSE_OPTION_DETAIL, PARAM_NAME_LICENSE_OPTION_DETAIL_NAME, it))
+                .getId())
+            .toList();
+
+        return optionDetailMultipleStockManageService.decrementLicense(licenseOptionDetailId, dto.getProductDto().getQuantity()).getOrThrow();
+    }
+
     private List<OptionDetail> getOptionDetails(OrderCreateRequestDto dto) {
         List<String> optionDetailIds = dto.getProductDto().getOptionDetailIds().stream()
                 .map(it -> optionDetailRepository.findById(it)
                         .orElseThrow(() -> new ResourceNotFoundException(RESOURCE_NAME_OPTION_DETAIL, PARAM_NAME_OPTION_DETAIL_NAME, it))
                         .getId())
                 .toList();
+
         return optionDetailMultipleStockManageService.decrement(optionDetailIds, dto.getProductDto().getQuantity()).getOrThrow();
     }
 
@@ -207,6 +217,7 @@ public class OrderCreateServiceImpl implements OrderCreateService {
                             .map(CustomProductOption::getOptionDetail)
                             .map(OptionDetail::getId)
                             .toList();
+                    //TODO: if 써서 license option detail id 추가
                     optionDetailMultipleStockManageService.decrement(optionIds, customProduct.getQuantity()).getOrThrow();
                 })
                 .toList();

--- a/liberty-main-service/src/main/java/com/liberty52/main/service/applicationservice/impl/OrderFailedPayRollbackServiceImpl.java
+++ b/liberty-main-service/src/main/java/com/liberty52/main/service/applicationservice/impl/OrderFailedPayRollbackServiceImpl.java
@@ -1,6 +1,7 @@
 package com.liberty52.main.service.applicationservice.impl;
 
 import com.liberty52.main.global.exception.external.notfound.ResourceNotFoundException;
+import com.liberty52.main.service.applicationservice.LicenseOptionDetailStockManageService;
 import com.liberty52.main.service.applicationservice.OptionDetailStockManageService;
 import com.liberty52.main.service.applicationservice.OrderFailedPayRollbackService;
 import com.liberty52.main.service.entity.CustomProductOption;
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderFailedPayRollbackServiceImpl implements OrderFailedPayRollbackService {
 
     private final OptionDetailStockManageService optionDetailStockManageService;
+    private final LicenseOptionDetailStockManageService licenseOptionDetailStockManageService;
     private final OrdersRepository ordersRepository;
 
     @Override
@@ -24,9 +26,15 @@ public class OrderFailedPayRollbackServiceImpl implements OrderFailedPayRollback
                 .orElseThrow(() -> new ResourceNotFoundException("order", "id", orderId));
 
         order.getCustomProducts().forEach(cp -> {
-            cp.getOptions().stream()
+            if(cp.getProduct().isCustom()){
+                cp.getOptions().stream()
                     .map(CustomProductOption::getOptionDetail)
                     .forEach(it -> optionDetailStockManageService.increment(it.getId(), cp.getQuantity()));
+            }else{
+                licenseOptionDetailStockManageService.increment(cp.getCustomLicenseOption().getLicenseOptionDetail().getId(), cp.getQuantity());
+            }
+
         });
     }
+
 }

--- a/liberty-main-service/src/main/java/com/liberty52/main/service/entity/license/LicenseOptionDetail.java
+++ b/liberty-main-service/src/main/java/com/liberty52/main/service/entity/license/LicenseOptionDetail.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.Optional;
 import java.util.UUID;
 
 @Entity
@@ -78,6 +79,23 @@ public class LicenseOptionDetail {
 
     public void updateOnSale() {
         onSale = !onSale;
+    }
+
+    public Optional<LicenseOptionDetail> sold(int quantity) {
+        synchronized (this) {
+            int stockAfterSold = stock - quantity;
+            if (!onSale || stock == 0 || stockAfterSold < 0) {
+                return Optional.empty();
+            }
+            stock = stockAfterSold;
+            return Optional.of(this);
+        }
+    }
+
+    public void rollbackStock(int quantity) {
+        synchronized (this) {
+            this.stock += quantity;
+        }
     }
 
 }

--- a/liberty-main-service/src/test/java/com/liberty52/main/service/applicationservice/impl/OrderCreateServiceImplUnitTest.java
+++ b/liberty-main-service/src/test/java/com/liberty52/main/service/applicationservice/impl/OrderCreateServiceImplUnitTest.java
@@ -151,9 +151,13 @@ class OrderCreateServiceImplUnitTest {
         CustomLicenseOption customLicenseOption = MockFactory.createCustomLicenseOption(customProduct, licenseOptionDetail);
         given(customLicenseOptionRepository.save(any())).willReturn(customLicenseOption);
 
-
         var order = MockFactory.createOrder(authId);
         given(ordersRepository.save(any())).willReturn(order);
+
+        List<LicenseOptionDetail> mockObject = List.of(licenseOptionDetail);
+
+        given(optionDetailMultipleStockManageService.decrementLicense(any(), anyInt()))
+            .willReturn(Result.success(mockObject));
 
         // when
         var result = executeCardPaymentOrders(authId, List.of(licenseOptionDetail.getId()), 1);


### PR DESCRIPTION
Resolve #366

***
### 작업
- 라이선스 상품 구매
- 라이선스 장바구니 구매
- 라이선스 상품 주문 시 라이선스 옵션에서 해당 옵션의 재고 감소 (가상계좌, 카드)

### 테스트
- 라이선스 상품 카드 결제(재고량 감소 잘 됨)
![image](https://github.com/Liberty52/product/assets/55132026/2a2c1538-572c-4bfb-b446-a83ad9415416)
![image](https://github.com/Liberty52/product/assets/55132026/035603ad-9585-4e1b-a95a-97c272a0c90f)
![image](https://github.com/Liberty52/product/assets/55132026/1daa8e01-b3f4-4338-81c1-0e4cb61c103d)

- 라이선스 상품 가상 계좌 결제(재고량 감소 잘 됨)
![image](https://github.com/Liberty52/product/assets/55132026/043f2eb7-7c40-4423-a5d0-1fc7c072a3a7)

- curl 명령어를 통한 동시성 처리도 잘 됨
![image](https://github.com/Liberty52/product/assets/55132026/311c5560-9c5f-43ba-80cb-c2e04f933192)



***