### PR TITLE
[버그픽스] 라벨러 PR을 DRAFT로 생성 시 작동 안됨

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types:
       - opened
+      - converted_to_draft
 
 jobs:
   main:


### PR DESCRIPTION
### 작업
bugfix(#415): Expanded the triggering conditions to include 'converted_to_draft' events in addition to 'opened'. 

```yaml
on:
  pull_request:
    types:
      - opened
      - converted_to_draft
```


### 테스트 결과
![image](https://github.com/Liberty52/product/assets/46955032/309b9d8d-9603-4d17-8813-af6728638839)



### 이슈
Closes #415 
